### PR TITLE
Add CLI Printer formats Bold/Italic/Underline/etc & Fix PHP Notice exception.

### DIFF
--- a/lib/Output/CliColors.php
+++ b/lib/Output/CliColors.php
@@ -20,6 +20,12 @@ class CliColors
     static $BG_WHITE = '47';
     static $BG_MAGENTA = '45';
 
+    static $BOLD = '1';
+    static $DIM = '2';
+    static $ITALIC = '3';
+    static $UNDERLINE = '4';
+    static $INVERT = '7';
+
     static $THEME_REGULAR = 1;
     static $THEME_UNICORN = 2;
 
@@ -33,7 +39,12 @@ class CliColors
             'success'     => [ CliColors::$FG_GREEN ],
             'success_alt' => [ CliColors::$FG_WHITE, CliColors::$BG_GREEN ],
             'info'        => [ CliColors::$FG_CYAN],
-            'info_alt'    => [ CliColors::$FG_WHITE, CliColors::$BG_CYAN ]
+            'info_alt'    => [ CliColors::$FG_WHITE, CliColors::$BG_CYAN ],
+            'bold'        => [ CliColors::$BOLD ],
+            'dim'         => [ CliColors::$DIM ],
+            'italic'      => [ CliColors::$ITALIC ],
+            'underline'   => [ CliColors::$UNDERLINE ],
+            'invert'      => [ CliColors::$INVERT ]
         ];
 
         $themes['unicorn'] = [
@@ -44,7 +55,12 @@ class CliColors
             'success'     => [ CliColors::$FG_GREEN ],
             'success_alt' => [ CliColors::$FG_BLACK, CliColors::$BG_GREEN ],
             'info'        => [ CliColors::$FG_MAGENTA],
-            'info_alt'    => [ CliColors::$FG_WHITE, CliColors::$BG_MAGENTA ]
+            'info_alt'    => [ CliColors::$FG_WHITE, CliColors::$BG_MAGENTA ],
+            'bold'        => [ CliColors::$BOLD ],
+            'dim'         => [ CliColors::$DIM ],
+            'italic'      => [ CliColors::$ITALIC ],
+            'underline'   => [ CliColors::$UNDERLINE ],
+            'invert'      => [ CliColors::$INVERT ]
         ];
 
         return isset($themes[$name]) ? $themes[$name] : $themes['regular'];

--- a/lib/Output/CliTheme.php
+++ b/lib/Output/CliTheme.php
@@ -14,6 +14,6 @@ class CliTheme
 
     public function __get($name)
     {
-        return $this->styles[$name] ? $this->styles[$name] : null;
+        return array_key_exists($name, $this->styles) ? $this->styles[$name] : null;
     }
 }


### PR DESCRIPTION
Hi!

Thanks for this great project, having a lot of fun with it.

If you're interested, I added a few more common formatting options to the CLI Printer:

- bold
- italic
- underline
- dim
- invert

And fixed a PHP Notice exception that was being thrown for an un-found style name (PHP 7.3):

```
PHP Notice:  Undefined index: foobar in /Minicli/vendor/minicli/minicli/lib/Output/CliTheme.php on line 17
```