### PR TITLE
More formatting style options for Default theme.

### DIFF
--- a/src/Output/CLIColors.php
+++ b/src/Output/CLIColors.php
@@ -19,4 +19,10 @@ class CLIColors
     static $BG_CYAN = '46';
     static $BG_WHITE = '47';
     static $BG_MAGENTA = '45';
+
+    static $BOLD = '1';
+    static $DIM = '2';
+    static $ITALIC = '3';
+    static $UNDERLINE = '4';
+    static $INVERT = '7';
 }

--- a/src/Output/CLITheme.php
+++ b/src/Output/CLITheme.php
@@ -29,7 +29,12 @@ class CLITheme implements CLIThemeInterface
             'success'     => [ CLIColors::$FG_GREEN ],
             'success_alt' => [ CLIColors::$FG_WHITE, CLIColors::$BG_GREEN ],
             'info'        => [ CLIColors::$FG_CYAN],
-            'info_alt'    => [ CLIColors::$FG_WHITE, CLIColors::$BG_CYAN ]
+            'info_alt'    => [ CLIColors::$FG_WHITE, CLIColors::$BG_CYAN ],
+            'bold'        => [ CliColors::$BOLD ],
+            'dim'         => [ CliColors::$DIM ],
+            'italic'      => [ CliColors::$ITALIC ],
+            'underline'   => [ CliColors::$UNDERLINE ],
+            'invert'      => [ CliColors::$INVERT ]
         ];
     }
 


### PR DESCRIPTION
I added a few more common formatting options to the CLI Printer:

- bold
- italic
- underline
- dim
- invert

Defined in default theme.

Unicorn theme file is not used yet as far as I can tell (does not use theme value from config). So once themes are implemented, these might have to be defined in each theme file. Or... might want to make it so that if anything is not defined in a specific theme (like unicorn), it looks for it in the default theme.
I can submit another PR once themes are implemented if necessary.