### PR TITLE
Catch unfound command error for nicer user output.

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -152,7 +152,13 @@ class App
      */
     protected function runSingle(CommandCall $input)
     {
-        $callable = $this->command_registry->getCallable($input->command);
+        try {
+            $callable = $this->command_registry->getCallable($input->command);
+        } catch (\Minicli\Exception\CommandNotFoundException $e){
+            $this->getPrinter()->error($e->getMessage());
+            return false;
+        }
+
         if (is_callable($callable)) {
             call_user_func($callable, $input);
             return true;


### PR DESCRIPTION
Mistyping errors is something users of the cli tool might do often. I think it might be nicer to not show a big PHP stack trace when this happens.

So I'm catching the CommandNotFoundException instead and printing the message in the 'error' style and terminate.

So instead of the PHP stack error, users see this:

```bash
./minicli blah

Command "blah" not found.

```