### PR TITLE
Handle exceptions based on a debug settings flag.

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -23,7 +23,7 @@ class App
     {
         $config = array_merge([
             'app_path' => __DIR__ . '/../app/Command',
-            'debug' => false,
+            'debug' => true,
         ], $config);
 
         $this->setSignature('./minicli help');

--- a/src/App.php
+++ b/src/App.php
@@ -23,6 +23,7 @@ class App
     {
         $config = array_merge([
             'app_path' => __DIR__ . '/../app/Command',
+            'debug' => false,
         ], $config);
 
         $this->setSignature('./minicli help');
@@ -152,10 +153,24 @@ class App
      */
     protected function runSingle(CommandCall $input)
     {
-        $callable = $this->command_registry->getCallable($input->command);
+        try {
+            $callable = $this->command_registry->getCallable($input->command);
+        } catch(\Exception $e) {
+            if (!$this->config->debug) {
+                $this->getPrinter()->error($e->getMessage());
+                return false;
+            }
+            throw $e;
+        }
+
         if (is_callable($callable)) {
             call_user_func($callable, $input);
             return true;
+        }
+
+        if (!$this->config->debug) {
+            $this->getPrinter()->error("The registered command is not a callable function.");
+            return false;
         }
 
         throw new CommandNotFoundException("The registered command is not a callable function.");


### PR DESCRIPTION
New config setting 'debug' which defaults to true.

Catch exceptions when executing commands, and if debug is false - show a nice error formatted message. Otherwise throw the error for testing/debugging/development.

Replacement for PR #7.

