### PR TITLE
Removing unused namespaces and consistency style

### DIFF
--- a/tests/Assets/Command/Test/DefaultController.php
+++ b/tests/Assets/Command/Test/DefaultController.php
@@ -2,7 +2,6 @@
 
 namespace Assets\Command\Test;
 
-use Minicli\App;
 use Minicli\Command\CommandController;
 
 class DefaultController extends CommandController

--- a/tests/Assets/Command/Test/HelpController.php
+++ b/tests/Assets/Command/Test/HelpController.php
@@ -2,7 +2,6 @@
 
 namespace Assets\Command\Test;
 
-use Minicli\App;
 use Minicli\Command\CommandController;
 
 class HelpController extends CommandController

--- a/tests/Assets/Command/Test/ParamsController.php
+++ b/tests/Assets/Command/Test/ParamsController.php
@@ -2,7 +2,6 @@
 
 namespace Assets\Command\Test;
 
-use Minicli\App;
 use Minicli\Command\CommandController;
 
 class ParamsController extends CommandController

--- a/tests/Assets/Command/Test/TableController.php
+++ b/tests/Assets/Command/Test/TableController.php
@@ -2,7 +2,6 @@
 
 namespace Assets\Command\Test;
 
-use Minicli\App;
 use Minicli\Command\CommandController;
 use Minicli\Output\Helper\TableHelper;
 

--- a/tests/Assets/Theme/CustomTheme.php
+++ b/tests/Assets/Theme/CustomTheme.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Assets\Theme;
 
 use Minicli\Output\CLIColors;

--- a/tests/Feature/Command/CommandRegistryTest.php
+++ b/tests/Feature/Command/CommandRegistryTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Minicli\App;
-use Minicli\Command\CommandRegistry;
 use Minicli\Command\CommandNamespace;
 use Minicli\Exception\CommandNotFoundException;
 

--- a/tests/Feature/Output/FilePrinterAdapterTest.php
+++ b/tests/Feature/Output/FilePrinterAdapterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Minicli\Output\Adapter\FilePrinterAdapter;
 use Minicli\Output\OutputHandler;
 

--- a/tests/Feature/Output/TableHelperTest.php
+++ b/tests/Feature/Output/TableHelperTest.php
@@ -1,6 +1,6 @@
 <?php
+
 use Minicli\Output\Helper\TableHelper;
-use Minicli\Output\Filter\ColorOutputFilter;
 
 it('asserts that TableHelper creates table from constructor', function () {
     $table = [

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -3,9 +3,6 @@
 use Minicli\App;
 use Minicli\Command\CommandCall;
 use Minicli\Command\CommandRegistry;
-use Minicli\Output\OutputHandler;
-use Minicli\Output\Filter\ColorOutputFilter;
-use Minicli\Output\CLIColors;
 
 function getCommandsPath()
 {


### PR DESCRIPTION
# Changed log

- Removing unused namespaces.
- Removing some new lines because it's for consistency coding style.