### PR TITLE
Fixing #29 - now obtaining flags also without --

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor/
 .php_cs.cache
+.phpunit.result.cache

--- a/src/Command/CommandCall.php
+++ b/src/Command/CommandCall.php
@@ -2,6 +2,8 @@
 
 namespace Minicli\Command;
 
+use Assets\Command\Test\ParamsController;
+
 class CommandCall
 {
     /** @var string  */
@@ -70,7 +72,11 @@ class CommandCall
      */
     public function hasFlag($flag)
     {
-        return in_array($flag, $this->flags);
+        if (in_array($flag, $this->flags)) {
+            return true;
+        }
+
+        return in_array('--' . $flag, $this->flags);
     }
 
     /**

--- a/tests/Feature/Command/CommandCallTest.php
+++ b/tests/Feature/Command/CommandCallTest.php
@@ -17,6 +17,12 @@ it('asserts flags are correctly set', function () {
     $this->assertContains("--flag", $call->getFlags());
 });
 
+it('asserts flags can be obtained without "--"', function () {
+    $call = new CommandCall(["minicli", "help", "test", "--flag"]);
+
+    $this->assertTrue($call->hasFlag('flag'));
+});
+
 it('asserts params are correctly set', function () {
     $call = new CommandCall(["minicli", "help", "test", "name=test"]);
 


### PR DESCRIPTION
This fixes issue #29 where the `hasFlag` method didn't work as expected and as explained in the [documentation](https://docs.minicli.dev/en/latest/03-input-arguments/).

In order to not break code that is already using `--flagname` within the `hasFlag` method, it now accounts for both ways, so if you call a command like this:

```shell
minicli hello test --myflag
```

Both `$this->hasFlag('myflag')` and ` $this->hasFlag('--myflag')` now work.