### PR TITLE
Including "Dalton" theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 vendor/
 .php_cs.cache
 .phpunit.result.cache
+.composer
+docker-compose.yml
+Dockerfile

--- a/src/Output/CLIColors.php
+++ b/src/Output/CLIColors.php
@@ -11,6 +11,7 @@ class CLIColors
     public static $FG_BLUE = '1;34';
     public static $FG_CYAN = '0;36';
     public static $FG_MAGENTA = '0;35';
+    public static $FG_YELLOW = '0;33';
 
     public static $BG_BLACK = '40';
     public static $BG_RED = '41';
@@ -19,6 +20,7 @@ class CLIColors
     public static $BG_CYAN = '46';
     public static $BG_WHITE = '47';
     public static $BG_MAGENTA = '45';
+    public static $BG_YELLOW = '43';
 
     public static $BOLD = '1';
     public static $DIM = '2';

--- a/src/Output/Theme/DaltonTheme.php
+++ b/src/Output/Theme/DaltonTheme.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Minicli\Output\Theme;
+
+use Minicli\Output\CLIColors;
+
+class DaltonTheme extends DefaultTheme
+{
+    public function getThemeColors(): array
+    {
+        return [
+            'default'     => [ CLIColors::$FG_YELLOW ],
+            'alt'         => [ CLIColors::$FG_BLACK, CLIColors::$BG_YELLOW ],
+            'error'       => [ CLIColors::$FG_RED ],
+            'error_alt'   => [ CLIColors::$FG_WHITE, CLIColors::$BG_RED ],
+            'success'     => [ CliColors::$FG_CYAN ],
+            'success_alt' => [ CLIColors::$FG_BLACK, CLIColors::$BG_CYAN ],
+            'info'        => [ CLIColors::$FG_MAGENTA],
+            'info_alt'    => [ CLIColors::$FG_WHITE, CLIColors::$BG_MAGENTA ]
+        ];
+    }
+}

--- a/tests/Feature/Output/CLIThemeTest.php
+++ b/tests/Feature/Output/CLIThemeTest.php
@@ -3,6 +3,7 @@
 use Minicli\Output\Theme\DefaultTheme;
 use Minicli\Output\Theme\UnicornTheme;
 use Minicli\Output\CLIColors;
+use Minicli\Output\Theme\DaltonTheme;
 
 it('asserts that Default CLI theme sets all default styles', function () {
     $theme = new DefaultTheme();
@@ -38,6 +39,29 @@ it('asserts that Unicorn CLI theme sets all default styles', function () {
 
 it('asserts that missing styles in Unicorn CLI theme are included from default theme', function () {
     $theme = new UnicornTheme();
+
+    $this->assertArrayHasKey('italic', $theme->styles);
+    $this->assertArrayHasKey('bold', $theme->styles);
+    $this->assertArrayHasKey('dim', $theme->styles);
+    $this->assertArrayHasKey('underline', $theme->styles);
+    $this->assertArrayHasKey('invert', $theme->styles);
+});
+
+it('asserts that Dalton CLI theme sets all default styles', function () {
+    $theme = new DaltonTheme();
+
+    $this->assertIsArray($theme->getStyle('default'));
+    $this->assertIsArray($theme->getStyle('alt'));
+    $this->assertIsArray($theme->getStyle('info'));
+    $this->assertIsArray($theme->getStyle('info_alt'));
+    $this->assertIsArray($theme->getStyle('error'));
+    $this->assertIsArray($theme->getStyle('error_alt'));
+    $this->assertIsArray($theme->getStyle('success'));
+    $this->assertIsArray($theme->getStyle('success_alt'));
+});
+
+it('asserts that missing styles in Dalton CLI theme are included from default theme', function () {
+    $theme = new DaltonTheme();
 
     $this->assertArrayHasKey('italic', $theme->styles);
     $this->assertArrayHasKey('bold', $theme->styles);

--- a/tests/Feature/Output/ThemeHelperTest.php
+++ b/tests/Feature/Output/ThemeHelperTest.php
@@ -3,12 +3,20 @@
 use Minicli\Output\Helper\ThemeHelper;
 use Minicli\Output\Theme\UnicornTheme;
 use Assets\Theme\CustomTheme;
+use Minicli\Output\Theme\DaltonTheme;
 
 it('asserts that ThemeHelper instantiates the right existing theme', function () {
     $helper = new ThemeHelper('\Unicorn');
     $filter = $helper->getOutputFilter();
 
     $this->assertInstanceOf(UnicornTheme::class, $filter->getTheme());
+});
+
+it('asserts that ThemeHelper instantiates Dalton theme', function () {
+    $helper = new ThemeHelper('\Dalton');
+    $filter = $helper->getOutputFilter();
+
+    $this->assertInstanceOf(DaltonTheme::class, $filter->getTheme());
 });
 
 it('asserts that ThemeHelper instantiates a custom theme', function () {


### PR DESCRIPTION
This PR implements a new color theme for minicli, the Dalton theme. Quoting Github: "_Color blindness affects up to 8% of people worldwide, with the majority affected by the red/green color spectrum_". Given these facts, the Dalton theme combines colors so that colorblind users do not suffer from misunderstandings in the colors of different types of messages.

The theme is defined as we can see below:

![image](https://user-images.githubusercontent.com/18440704/139504330-37da25ba-9a83-49b9-8ad6-a1175ad83c35.png)


and the default output colors are:

![image](https://user-images.githubusercontent.com/18440704/138942720-94b80ba6-eb60-452d-8484-d726c57036c8.png)

These combined defined colors cover some types of color blindness. The output colors we saw above will not be confused with each other, as is often the case with a standard color palette. As you can see from the list below, a person with any of those color blindness types will see a different version of the default colors, but not the same color for different messages.

For example, this is the Unicorn theme seen by a person with Blue-Blind/Tritanopia type of color blindness:
![image](https://user-images.githubusercontent.com/18440704/138982853-751e8b6b-2e0d-4f45-a380-807614355fd6.png)

These are examples of Dalton theme seen by a person with different types of color blindness:

- Red-Weak/Protanomaly:
![image](https://user-images.githubusercontent.com/18440704/138942949-60c842a3-addc-471a-b7f2-7863b3dc68f4.png)

- Green-Weak/Deuteranomaly:
![image](https://user-images.githubusercontent.com/18440704/138943143-b68a6de6-cc99-4857-97c9-188132daad0d.png)

- Blue-Weak/Tritanomaly:
![image](https://user-images.githubusercontent.com/18440704/138943315-16bdfb83-a63c-42b1-91c0-af3835811b3c.png)

- Red-Blind/Protanopia:
![image](https://user-images.githubusercontent.com/18440704/138943383-72232679-5975-469a-9e8f-33b0208eef0c.png)

- Green-Blind/Deuteranopia:
![image](https://user-images.githubusercontent.com/18440704/138943527-5ea097bd-4acc-4edc-ab7e-b42ffd793c8e.png)

- Blue-Blind/Tritanopia:
![image](https://user-images.githubusercontent.com/18440704/138943612-5e5d671e-10be-4b9d-b503-fffe258979d8.png)

 