### PR TITLE
PHP 8 support & code code clean up 

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,7 +21,7 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run test suite
-      run: ./vendor/bin/pest
+      run: composer test
 
     - name: Run php-cs-fixer
-      run: ./vendor/bin/php-cs-fixer fix
+      run: composer csfix

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Quick links:
 
 What does it mean to be dependency-free? It means that you can build a working CLI PHP application without dozens of nested user-land dependencies. The basic `minicli/minicli` package has only **testing** dependencies, and a single system requirement:
 
-- PHP >= 7.3
+- PHP >= 8
 
 > Note: If you want to obtain user input, then the [`readline`](https://www.php.net/manual/en/function.readline.php) PHP extension is required as well.
 

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,16 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.3"
+    "php": ">=8"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",
     "pestphp/pest": "^1.0",
-    "friendsofphp/php-cs-fixer": "^2.16"
+    "friendsofphp/php-cs-fixer": "^3.5"
+  },
+  "scripts": {
+    "test" : ["pest"],
+    "csfix": ["php-cs-fixer fix"]
   },
   "suggest": {
     "ext-readline": "For obtaining user input"

--- a/composer.lock
+++ b/composer.lock
@@ -4,28 +4,99 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b045b45b931f67ddef49b251fa68b44",
+    "content-hash": "0b83761c262dfc9fb027419bd3ce3de9",
     "packages": [],
     "packages-dev": [
         {
-            "name": "composer/semver",
-            "version": "3.2.4",
+            "name": "composer/pcre",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
-                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.54",
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-21T20:24:37+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a951f614bd64dcd26137bc9b7b2637ddcfc57649",
+                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
@@ -70,7 +141,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.4"
+                "source": "https://github.com/composer/semver/tree/3.2.9"
             },
             "funding": [
                 {
@@ -86,28 +157,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:59:24+00:00"
+            "time": "2022-02-04T13:58:43+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.5",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/12f1b79476638a5615ed00ea6adbb269cec96fd8",
+                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "composer/pcre": "^1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -133,7 +207,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.1"
             },
             "funding": [
                 {
@@ -149,32 +223,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:04:11+00:00"
+            "time": "2022-01-04T18:29:42+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.12.1",
+            "version": "1.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b"
+                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/b17c5014ef81d212ac539f07a1001832df1b6d3b",
-                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5b668aef16090008790395c02c893b1ba13f7e08",
+                "reference": "5b668aef16090008790395c02c893b1ba13f7e08",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
                 "ext-tokenizer": "*",
-                "php": "^7.1 || ^8.0"
+                "php": "^7.1 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "doctrine/cache": "1.*",
+                "doctrine/cache": "^1.11 || ^2.0",
                 "doctrine/coding-standard": "^6.0 || ^8.1",
                 "phpstan/phpstan": "^0.12.20",
-                "phpunit/phpunit": "^7.5 || ^9.1.5"
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
+                "symfony/cache": "^4.4 || ^5.2"
             },
             "type": "library",
             "autoload": {
@@ -217,9 +293,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.12.1"
+                "source": "https://github.com/doctrine/annotations/tree/1.13.2"
             },
-            "time": "2021-02-21T21:00:45+00:00"
+            "time": "2021-08-05T19:00:23+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -292,32 +368,28 @@
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
+                "reference": "9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
-                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c",
+                "reference": "9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
-                "phpstan/phpstan": "^0.11.8",
-                "phpunit/phpunit": "^8.2"
+                "doctrine/coding-standard": "^9.0",
+                "phpstan/phpstan": "1.3",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.11"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
@@ -352,7 +424,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.1"
+                "source": "https://github.com/doctrine/lexer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -368,7 +440,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-25T17:44:05+00:00"
+            "time": "2022-01-12T08:27:12+00:00"
         },
         {
             "name": "facade/ignition-contracts",
@@ -425,21 +497,21 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.9.2",
+            "version": "2.14.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "df7933820090489623ce0be5e85c7e693638e536"
+                "reference": "a63e5e8f26ebbebf8ed3c5c691637325512eb0dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/df7933820090489623ce0be5e85c7e693638e536",
-                "reference": "df7933820090489623ce0be5e85c7e693638e536",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/a63e5e8f26ebbebf8ed3c5c691637325512eb0dc",
+                "reference": "a63e5e8f26ebbebf8ed3c5c691637325512eb0dc",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9 || ^7.0 || ^8.0",
-                "psr/log": "^1.0.1"
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "require-dev": {
                 "mockery/mockery": "^0.9 || ^1.0",
@@ -484,7 +556,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.9.2"
+                "source": "https://github.com/filp/whoops/tree/2.14.5"
             },
             "funding": [
                 {
@@ -492,62 +564,60 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-24T12:00:00+00:00"
+            "time": "2022-01-07T12:00:00+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.18.2",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "18f8c9d184ba777380794a389fabc179896ba913"
+                "reference": "333f15e07c866e33e2765e84ba1e0b88e6a3af3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/18f8c9d184ba777380794a389fabc179896ba913",
-                "reference": "18f8c9d184ba777380794a389fabc179896ba913",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/333f15e07c866e33e2765e84ba1e0b88e6a3af3b",
+                "reference": "333f15e07c866e33e2765e84ba1e0b88e6a3af3b",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.2",
-                "doctrine/annotations": "^1.2",
+                "composer/semver": "^3.2",
+                "composer/xdebug-handler": "^3.0",
+                "doctrine/annotations": "^1.13",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
-                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
-                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
-                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
-                "symfony/polyfill-php70": "^1.0",
-                "symfony/polyfill-php72": "^1.4",
-                "symfony/process": "^3.0 || ^4.0 || ^5.0",
-                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+                "php": "^7.4 || ^8.0",
+                "php-cs-fixer/diff": "^2.0",
+                "symfony/console": "^5.4 || ^6.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0",
+                "symfony/filesystem": "^5.4 || ^6.0",
+                "symfony/finder": "^5.4 || ^6.0",
+                "symfony/options-resolver": "^5.4 || ^6.0",
+                "symfony/polyfill-mbstring": "^1.23",
+                "symfony/polyfill-php80": "^1.23",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/process": "^5.4 || ^6.0",
+                "symfony/stopwatch": "^5.4 || ^6.0"
             },
             "require-dev": {
-                "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.4",
-                "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.4.2",
-                "php-cs-fixer/accessible-object": "^1.0",
+                "justinrainbow/json-schema": "^5.2",
+                "keradus/cli-executor": "^1.5",
+                "mikey179/vfsstream": "^1.6.10",
+                "php-coveralls/php-coveralls": "^2.5.2",
+                "php-cs-fixer/accessible-object": "^1.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
-                "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.5",
+                "phpspec/prophecy": "^1.15",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
                 "phpunitgoodpractices/polyfill": "^1.5",
                 "phpunitgoodpractices/traits": "^1.9.1",
-                "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
-                "symfony/phpunit-bridge": "^5.2.1",
-                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+                "symfony/phpunit-bridge": "^6.0",
+                "symfony/yaml": "^5.4 || ^6.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
-                "ext-mbstring": "For handling non-UTF8 characters.",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
-                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+                "ext-mbstring": "For handling non-UTF8 characters."
             },
             "bin": [
                 "php-cs-fixer"
@@ -556,19 +626,7 @@
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
-                },
-                "classmap": [
-                    "tests/Test/AbstractFixerTestCase.php",
-                    "tests/Test/AbstractIntegrationCaseFactory.php",
-                    "tests/Test/AbstractIntegrationTestCase.php",
-                    "tests/Test/Assert/AssertTokensTrait.php",
-                    "tests/Test/IntegrationCase.php",
-                    "tests/Test/IntegrationCaseFactory.php",
-                    "tests/Test/IntegrationCaseFactoryInterface.php",
-                    "tests/Test/InternalIntegrationCaseFactory.php",
-                    "tests/Test/IsIdenticalConstraint.php",
-                    "tests/TestCase.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -587,7 +645,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.18.2"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -595,7 +653,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-26T00:22:21+00:00"
+            "time": "2022-01-14T00:29:20+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -624,12 +682,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -657,16 +715,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.4",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -707,44 +765,43 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2020-12-20T10:01:03+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v5.3.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "aca63581f380f63a492b1e3114604e411e39133a"
+                "reference": "df09e21a5e5d5a7d51a8b9ecd44d3dd150d97fec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/aca63581f380f63a492b1e3114604e411e39133a",
-                "reference": "aca63581f380f63a492b1e3114604e411e39133a",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/df09e21a5e5d5a7d51a8b9ecd44d3dd150d97fec",
+                "reference": "df09e21a5e5d5a7d51a8b9ecd44d3dd150d97fec",
                 "shasum": ""
             },
             "require": {
-                "facade/ignition-contracts": "^1.0",
-                "filp/whoops": "^2.7.2",
-                "php": "^7.3 || ^8.0",
-                "symfony/console": "^5.0"
+                "facade/ignition-contracts": "^1.0.2",
+                "filp/whoops": "^2.14.5",
+                "php": "^8.0.0",
+                "symfony/console": "^6.0.2"
             },
             "require-dev": {
-                "brianium/paratest": "^6.1",
-                "fideloper/proxy": "^4.4.1",
-                "friendsofphp/php-cs-fixer": "^2.17.3",
-                "fruitcake/laravel-cors": "^2.0.3",
+                "brianium/paratest": "^6.4.1",
                 "laravel/framework": "^9.0",
-                "nunomaduro/larastan": "^0.6.2",
-                "nunomaduro/mock-final-classes": "^1.0",
-                "orchestra/testbench": "^7.0",
-                "phpstan/phpstan": "^0.12.64",
-                "phpunit/phpunit": "^9.5.0"
+                "nunomaduro/larastan": "^1.0.2",
+                "nunomaduro/mock-final-classes": "^1.1.0",
+                "orchestra/testbench": "^7.0.0",
+                "phpunit/phpunit": "^9.5.11"
             },
             "type": "library",
             "extra": {
+                "branch-alias": {
+                    "dev-develop": "6.x-dev"
+                },
                 "laravel": {
                     "providers": [
                         "NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider"
@@ -785,7 +842,7 @@
             },
             "funding": [
                 {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
                     "type": "custom"
                 },
                 {
@@ -797,37 +854,34 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-01-25T15:34:13+00:00"
+            "time": "2022-01-18T17:49:08+00:00"
         },
         {
             "name": "pestphp/pest",
-            "version": "v1.0.2",
+            "version": "v1.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "fa130167857fe5daed0c281f1f14cd4a88c56184"
+                "reference": "92b8d32ef78c54c915641999e0c4167d7202b2d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/fa130167857fe5daed0c281f1f14cd4a88c56184",
-                "reference": "fa130167857fe5daed0c281f1f14cd4a88c56184",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/92b8d32ef78c54c915641999e0c4167d7202b2d9",
+                "reference": "92b8d32ef78c54c915641999e0c4167d7202b2d9",
                 "shasum": ""
             },
             "require": {
-                "nunomaduro/collision": "^5.0",
-                "pestphp/pest-plugin": "^1.0",
-                "pestphp/pest-plugin-coverage": "^1.0",
-                "pestphp/pest-plugin-expectations": "^1.0",
-                "pestphp/pest-plugin-init": "^1.0",
+                "nunomaduro/collision": "^5.4.0|^6.0",
+                "pestphp/pest-plugin": "^1.0.0",
                 "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": ">= 9.3.7 <= 9.5.2"
+                "phpunit/phpunit": "^9.5.5"
             },
             "require-dev": {
-                "illuminate/console": "^8.0",
-                "illuminate/support": "^8.0",
-                "laravel/dusk": "^6.9.1",
-                "mockery/mockery": "^1.4.1",
-                "pestphp/pest-dev-tools": "dev-master"
+                "illuminate/console": "^8.47.0",
+                "illuminate/support": "^8.47.0",
+                "laravel/dusk": "^6.15.0",
+                "pestphp/pest-dev-tools": "dev-master",
+                "pestphp/pest-plugin-parallel": "^1.0"
             },
             "bin": [
                 "bin/pest"
@@ -839,7 +893,10 @@
                 },
                 "pest": {
                     "plugins": [
-                        "Pest\\Plugins\\Version"
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Environment"
                     ]
                 },
                 "laravel": {
@@ -878,12 +935,16 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v1.0.2"
+                "source": "https://github.com/pestphp/pest/tree/v1.21.1"
             },
             "funding": [
                 {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
                     "type": "custom"
+                },
+                {
+                    "url": "https://github.com/lukeraymonddowning",
+                    "type": "github"
                 },
                 {
                     "url": "https://github.com/nunomaduro",
@@ -906,7 +967,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-02-04T09:15:54+00:00"
+            "time": "2021-11-25T16:44:17+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -981,243 +1042,17 @@
             "time": "2021-01-03T15:53:42+00:00"
         },
         {
-            "name": "pestphp/pest-plugin-coverage",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-coverage.git",
-                "reference": "50260c8671377a5082a06b9e228a984c13ed199c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-coverage/zipball/50260c8671377a5082a06b9e228a984c13ed199c",
-                "reference": "50260c8671377a5082a06b9e228a984c13ed199c",
-                "shasum": ""
-            },
-            "require": {
-                "pestphp/pest-plugin": "^1.0",
-                "php": "^7.3 || ^8.0",
-                "sebastian/environment": "^5.1.2"
-            },
-            "conflict": {
-                "pestphp/pest": "<1.0"
-            },
-            "require-dev": {
-                "pestphp/pest": "^1.0",
-                "pestphp/pest-dev-tools": "dev-master"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                },
-                "pest": {
-                    "plugins": [
-                        "Pest\\PluginCoverage\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\PluginCoverage\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Pest Coverage Plugin",
-            "keywords": [
-                "coverage",
-                "framework",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-coverage/tree/v1.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "abandoned": "pestphp/pest",
-            "time": "2021-01-03T15:51:41+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-expectations",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-expectations.git",
-                "reference": "e543acd6d0ca33c9bdaae05d4dffbfc8c66a0285"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-expectations/zipball/e543acd6d0ca33c9bdaae05d4dffbfc8c66a0285",
-                "reference": "e543acd6d0ca33c9bdaae05d4dffbfc8c66a0285",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "^9.0"
-            },
-            "conflict": {
-                "pestphp/pest": "<1.0"
-            },
-            "require-dev": {
-                "pestphp/pest": "^1.0",
-                "pestphp/pest-dev-tools": "dev-master"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Expectations\\": "src/"
-                },
-                "files": [
-                    "src/Autoload.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Add expectations testing capabilities to Pest or PHPUnit",
-            "keywords": [
-                "expectations",
-                "framework",
-                "pest",
-                "php",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-expectations/tree/v1.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "abandoned": "pestphp/pest",
-            "time": "2021-01-03T16:02:34+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-init",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-init.git",
-                "reference": "bd6fdb058ba5dc7a9f7f3645ad4e0bdc34cf0026"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-init/zipball/bd6fdb058ba5dc7a9f7f3645ad4e0bdc34cf0026",
-                "reference": "bd6fdb058ba5dc7a9f7f3645ad4e0bdc34cf0026",
-                "shasum": ""
-            },
-            "require": {
-                "pestphp/pest-plugin": "^1.0",
-                "php": "^7.3 || ^8.0"
-            },
-            "conflict": {
-                "pestphp/pest": "<1.0"
-            },
-            "require-dev": {
-                "pestphp/pest": "^1.0",
-                "pestphp/pest-dev-tools": "dev-master"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                },
-                "pest": {
-                    "plugins": [
-                        "Pest\\Init\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Init\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Pest Init plugin",
-            "keywords": [
-                "framework",
-                "init",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-init/tree/v1.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "abandoned": "pestphp/pest",
-            "time": "2021-01-03T15:47:48+00:00"
-        },
-        {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -1262,9 +1097,9 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
@@ -1319,16 +1154,16 @@
         },
         {
             "name": "php-cs-fixer/diff",
-            "version": "v1.3.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759"
+                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/dbd31aeb251639ac0b9e7e29405c1441907f5759",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/29dc0d507e838c4580d018bd8b5cb412474f7ec3",
+                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3",
                 "shasum": ""
             },
             "require": {
@@ -1356,21 +1191,18 @@
                 {
                     "name": "Kore Nordmann",
                     "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "SpacePossum"
                 }
             ],
-            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "description": "sebastian/diff v3 backport support for PHP 5.6+",
             "homepage": "https://github.com/PHP-CS-Fixer",
             "keywords": [
                 "diff"
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
-                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
+                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v2.0.2"
             },
-            "time": "2020-10-14T08:39:05+00:00"
+            "time": "2020-10-14T08:32:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1427,16 +1259,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -1447,7 +1279,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1477,22 +1310,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
                 "shasum": ""
             },
             "require": {
@@ -1500,7 +1333,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1526,39 +1360,39 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2022-01-04T19:58:01+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -1593,29 +1427,29 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "version": "9.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1664,7 +1498,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
             },
             "funding": [
                 {
@@ -1672,20 +1506,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2021-12-05T09:12:13+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -1724,7 +1558,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -1732,7 +1566,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -1917,16 +1751,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.2",
+            "version": "9.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
                 "shasum": ""
             },
             "require": {
@@ -1938,11 +1772,11 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.7",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -1956,7 +1790,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -2004,11 +1838,11 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
@@ -2016,29 +1850,78 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-02T14:45:58+00:00"
+            "time": "2022-01-24T07:33:35+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.0.0",
+            "name": "psr/cache",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2053,7 +1936,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -2067,9 +1950,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -2123,30 +2006,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2156,7 +2039,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -2167,9 +2050,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2600,16 +2483,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -2658,14 +2541,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2673,20 +2556,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -2729,7 +2612,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -2737,7 +2620,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -3028,16 +2911,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -3072,7 +2955,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -3080,7 +2963,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3137,44 +3020,42 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.3",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a"
+                "reference": "22e8efd019c3270c4f79376234a3f8752cd25490"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/89d4b176d12a2946a1ae4e34906a025b7b6b135a",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/22e8efd019c3270c4f79376234a3f8752cd25490",
+                "reference": "22e8efd019c3270c4f79376234a3f8752cd25490",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.4|^6.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/lock": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -3214,7 +3095,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.3"
+                "source": "https://github.com/symfony/console/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3230,29 +3111,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2022-01-26T17:23:29+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.2.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
+                "reference": "c726b64c1ccfe2896cb7df2e1331c357ad1c8ced"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/c726b64c1ccfe2896cb7df2e1331c357ad1c8ced",
+                "reference": "c726b64c1ccfe2896cb7df2e1331c357ad1c8ced",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3281,7 +3162,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.0"
             },
             "funding": [
                 {
@@ -3297,44 +3178,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-11-01T23:48:49+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.2.3",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "4f9760f8074978ad82e2ce854dff79a71fe45367"
+                "reference": "6472ea2dd415e925b90ca82be64b8bc6157f3934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4f9760f8074978ad82e2ce854dff79a71fe45367",
-                "reference": "4f9760f8074978ad82e2ce854dff79a71fe45367",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6472ea2dd415e925b90ca82be64b8bc6157f3934",
+                "reference": "6472ea2dd415e925b90ca82be64b8bc6157f3934",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
-                "symfony/event-dispatcher-contracts": "^2",
-                "symfony/polyfill-php80": "^1.15"
+                "php": ">=8.0.2",
+                "symfony/event-dispatcher-contracts": "^2|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4"
+                "symfony/dependency-injection": "<5.4"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/expression-language": "^4.4|^5.0",
-                "symfony/http-foundation": "^4.4|^5.0",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/stopwatch": "^4.4|^5.0"
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/stopwatch": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -3366,7 +3245,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3382,24 +3261,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:36:42+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.2.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2"
+                "reference": "aa5422287b75594b90ee9cd807caf8f0df491385"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ba7d54483095a198fa51781bc608d17e84dffa2",
-                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/aa5422287b75594b90ee9cd807caf8f0df491385",
+                "reference": "aa5422287b75594b90ee9cd807caf8f0df491385",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "psr/event-dispatcher": "^1"
             },
             "suggest": {
@@ -3408,7 +3287,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3445,7 +3324,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.2.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.0"
             },
             "funding": [
                 {
@@ -3461,25 +3340,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-07-15T12:33:35+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.3",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038"
+                "reference": "6ae49c4fda17322171a2b8dc5f70bc6edbc498e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/262d033b57c73e8b59cd6e68a45c528318b15038",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6ae49c4fda17322171a2b8dc5f70bc6edbc498e1",
+                "reference": "6ae49c4fda17322171a2b8dc5f70bc6edbc498e1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=8.0.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
             },
             "type": "library",
             "autoload": {
@@ -3507,7 +3387,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.3"
+                "source": "https://github.com/symfony/filesystem/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3523,24 +3403,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:01:46+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.3",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4adc8d172d602008c204c2e16956f99257248e03"
+                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4adc8d172d602008c204c2e16956f99257248e03",
-                "reference": "4adc8d172d602008c204c2e16956f99257248e03",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8661b74dbabc23223f38c9b99d3f8ade71170430",
+                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=8.0.2"
             },
             "type": "library",
             "autoload": {
@@ -3568,7 +3448,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.3"
+                "source": "https://github.com/symfony/finder/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3584,27 +3464,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2022-01-26T17:23:29+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.2.3",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "5d0f633f9bbfcf7ec642a2b5037268e61b0a62ce"
+                "reference": "51f7006670febe4cbcbae177cbffe93ff833250d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/5d0f633f9bbfcf7ec642a2b5037268e61b0a62ce",
-                "reference": "5d0f633f9bbfcf7ec642a2b5037268e61b0a62ce",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/51f7006670febe4cbcbae177cbffe93ff833250d",
+                "reference": "51f7006670febe4cbcbae177cbffe93ff833250d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
-                "symfony/polyfill-php73": "~1.0",
-                "symfony/polyfill-php80": "^1.15"
+                "php": ">=8.0.2",
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "type": "library",
             "autoload": {
@@ -3637,7 +3515,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.2.3"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3653,24 +3531,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T12:56:27+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -3678,7 +3559,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3716,7 +3597,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -3732,20 +3613,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
+                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
                 "shasum": ""
             },
             "require": {
@@ -3757,7 +3638,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3797,7 +3678,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -3813,20 +3694,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-11-23T21:10:46+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -3838,7 +3719,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3881,7 +3762,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -3897,24 +3778,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -3922,7 +3806,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3961,7 +3845,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -3977,243 +3861,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "metapackage",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.20-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php70/tree/v1.20.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-23T14:02:19+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php72",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.22-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-01-07T16:49:33+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.22-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-11-30T18:21:41+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.1",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
                 "shasum": ""
             },
             "require": {
@@ -4222,7 +3883,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4267,7 +3928,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
             },
             "funding": [
                 {
@@ -4283,25 +3944,103 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-09-13T13:58:33+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v5.2.3",
+            "name": "symfony/polyfill-php81",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f"
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
-                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
+                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.15"
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-13T13:58:11+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "298ed357274c1868c20a0061df256a1250a6c4af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/298ed357274c1868c20a0061df256a1250a6c4af",
+                "reference": "298ed357274c1868c20a0061df256a1250a6c4af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
             },
             "type": "library",
             "autoload": {
@@ -4329,7 +4068,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.2.3"
+                "source": "https://github.com/symfony/process/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -4345,25 +4084,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2022-01-26T17:23:29+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.2.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+                "reference": "36715ebf9fb9db73db0cb24263c79077c6fe8603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/36715ebf9fb9db73db0cb24263c79077c6fe8603",
+                "reference": "36715ebf9fb9db73db0cb24263c79077c6fe8603",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.0"
+                "php": ">=8.0.2",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -4371,7 +4113,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4408,7 +4150,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/master"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.0.0"
             },
             "funding": [
                 {
@@ -4424,25 +4166,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-11-04T17:53:12+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.2.3",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "b12274acfab9d9850c52583d136a24398cdf1a0c"
+                "reference": "6835045bb9f00fa4486ea4f1bcaf623be761556f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b12274acfab9d9850c52583d136a24398cdf1a0c",
-                "reference": "b12274acfab9d9850c52583d136a24398cdf1a0c",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/6835045bb9f00fa4486ea4f1bcaf623be761556f",
+                "reference": "6835045bb9f00fa4486ea4f1bcaf623be761556f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/service-contracts": "^1.0|^2"
+                "php": ">=8.0.2",
+                "symfony/service-contracts": "^1|^2|^3"
             },
             "type": "library",
             "autoload": {
@@ -4470,7 +4212,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.2.3"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -4486,35 +4228,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.3",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122"
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/c95468897f408dd0aca2ff582074423dd0455122",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122",
+                "url": "https://api.github.com/repos/symfony/string/zipball/522144f0c4c004c80d56fa47e40e17028e2eefc2",
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.0"
             },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4553,7 +4297,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.3"
+                "source": "https://github.com/symfony/string/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -4569,20 +4313,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-25T15:14:59+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -4611,7 +4355,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -4619,34 +4363,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -4670,9 +4419,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],
@@ -4681,8 +4430,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3"
+        "php": ">=8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/App.php
+++ b/src/App.php
@@ -108,12 +108,12 @@ class App
     /**
      * Shortcut for setting the Output Handler
      *
-     * @param OutputHandler $output_printer
+     * @param OutputHandler $outputPrinter
      * @return void
      */
-    public function setOutputHandler(OutputHandler $output_printer): void
+    public function setOutputHandler(OutputHandler $outputPrinter): void
     {
-        $this->services['printer'] = $output_printer;
+        $this->services['printer'] = $outputPrinter;
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -11,13 +11,13 @@ use Minicli\Output\OutputHandler;
 class App
 {
     /** @var  string  */
-    protected $app_signature;
+    protected $appSignature;
 
     /** @var  array */
     protected $services = [];
 
     /** @var array  */
-    protected $loaded_services = [];
+    protected $loadedServices = [];
 
     /**
      * App constructor.
@@ -32,7 +32,7 @@ class App
         ], $config);
 
         $this->addService('config', new Config($config));
-        $this->addService('command_registry', new CommandRegistry($this->config->app_path));
+        $this->addService('commandRegistry', new CommandRegistry($this->config->app_path));
 
         $this->setSignature($signature);
         $this->setTheme($this->config->theme);
@@ -49,7 +49,7 @@ class App
             return null;
         }
 
-        if (!array_key_exists($name, $this->loaded_services)) {
+        if (!array_key_exists($name, $this->loadedServices)) {
             $this->loadService($name);
         }
 
@@ -70,7 +70,7 @@ class App
      */
     public function loadService($name)
     {
-        $this->loaded_services[$name] = $this->services[$name]->load($this);
+        $this->loadedServices[$name] = $this->services[$name]->load($this);
     }
 
     /**
@@ -96,7 +96,7 @@ class App
      */
     public function getSignature()
     {
-        return $this->app_signature;
+        return $this->appSignature;
     }
 
     /**
@@ -107,23 +107,23 @@ class App
         $this->getPrinter()->display($this->getSignature());
     }
     /**
-     * @param string $app_signature
+     * @param string $appSignature
      */
-    public function setSignature($app_signature)
+    public function setSignature($appSignature)
     {
-        $this->app_signature = $app_signature;
+        $this->appSignature = $appSignature;
     }
 
     /**
      * Set the Output Handler based on the App's theme config setting.
-     * @param string $theme_config
+     * @param string $loadedServices
      */
-    public function setTheme(string $theme_config)
+    public function setTheme(string $loadedServices)
     {
         $output = new OutputHandler();
 
         $output->registerFilter(
-            (new ThemeHelper($theme_config))
+            (new ThemeHelper($loadedServices))
             ->getOutputFilter()
         );
 
@@ -136,7 +136,7 @@ class App
      */
     public function registerCommand($name, $callable)
     {
-        $this->command_registry->registerCommand($name, $callable);
+        $this->commandRegistry->registerCommand($name, $callable);
     }
 
     /**
@@ -152,7 +152,7 @@ class App
             return;
         }
 
-        $controller = $this->command_registry->getCallableController($input->command, $input->subcommand);
+        $controller = $this->commandRegistry->getCallableController($input->command, $input->subcommand);
 
         if ($controller instanceof ControllerInterface) {
             $controller->boot($this);
@@ -172,7 +172,7 @@ class App
     protected function runSingle(CommandCall $input)
     {
         try {
-            $callable = $this->command_registry->getCallable($input->command);
+            $callable = $this->commandRegistry->getCallable($input->command);
         } catch (\Exception $e) {
             if (!$this->config->debug) {
                 $this->getPrinter()->error($e->getMessage());

--- a/src/App.php
+++ b/src/App.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli;
 
 use Minicli\Command\CommandCall;
@@ -10,17 +12,30 @@ use Minicli\Output\OutputHandler;
 
 class App
 {
-    /** @var  string  */
-    protected $appSignature;
-
-    /** @var  array */
-    protected $services = [];
-
-    /** @var array  */
-    protected $loadedServices = [];
+    /**
+     * app signature
+     *
+     * @var string
+     */
+    protected string $appSignature;
 
     /**
-     * App constructor.
+     * app services
+     *
+     * @var array
+     */
+    protected array $services = [];
+
+    /**
+     * app loaded services
+     *
+     * @var array
+     */
+    protected array $loadedServices = [];
+
+    /**
+     * App constructor
+     *
      * @param array $config
      */
     public function __construct(array $config = [], string $signature = './minicli help')
@@ -39,11 +54,12 @@ class App
     }
 
     /**
-     * Magic method implements lazy loading for services.
+     * Magic method implements lazy loading for services
+     *
      * @param string $name
      * @return ServiceInterface|null
      */
-    public function __get($name)
+    public function __get(string $name): ?ServiceInterface
     {
         if (!array_key_exists($name, $this->services)) {
             return null;
@@ -57,24 +73,31 @@ class App
     }
 
     /**
+     * add app service
+     *
      * @param string $name
      * @param ServiceInterface $service
+     * @return void
      */
-    public function addService($name, ServiceInterface $service)
+    public function addService(string $name, ServiceInterface $service): void
     {
         $this->services[$name] = $service;
     }
 
     /**
+     * load app service
+     *
      * @param string $name
+     * @return void
      */
-    public function loadService($name)
+    public function loadService(string $name): void
     {
         $this->loadedServices[$name] = $this->services[$name]->load($this);
     }
 
     /**
      * Shortcut for accessing the Output Handler
+     *
      * @return OutputHandler
      */
     public function getPrinter(): OutputHandler
@@ -84,41 +107,53 @@ class App
 
     /**
      * Shortcut for setting the Output Handler
+     *
      * @param OutputHandler $output_printer
+     * @return void
      */
-    public function setOutputHandler(OutputHandler $output_printer)
+    public function setOutputHandler(OutputHandler $output_printer): void
     {
         $this->services['printer'] = $output_printer;
     }
 
     /**
+     * get app signature
+     *
      * @return string
      */
-    public function getSignature()
+    public function getSignature(): string
     {
         return $this->appSignature;
     }
 
     /**
+     * print signature
+     *
      * @return void
      */
-    public function printSignature()
+    public function printSignature(): void
     {
         $this->getPrinter()->display($this->getSignature());
     }
+
     /**
+     * set signature
+     *
      * @param string $appSignature
+     * @return void
      */
-    public function setSignature($appSignature)
+    public function setSignature(string $appSignature): void
     {
         $this->appSignature = $appSignature;
     }
 
     /**
-     * Set the Output Handler based on the App's theme config setting.
+     * Set the Output Handler based on the App's theme config setting
+     *
      * @param string $loadedServices
+     * @return void
      */
-    public function setTheme(string $loadedServices)
+    public function setTheme(string $loadedServices): void
     {
         $output = new OutputHandler();
 
@@ -131,19 +166,26 @@ class App
     }
 
     /**
+     * register app command
+     *
      * @param string $name
      * @param callable $callable
+     * @return void
      */
-    public function registerCommand($name, $callable)
+    public function registerCommand(string $name, callable $callable): void
     {
         $this->commandRegistry->registerCommand($name, $callable);
     }
 
     /**
+     * run command
+     *
      * @param array $argv
+     * @return void
+     *
      * @throws CommandNotFoundException
      */
-    public function runCommand(array $argv = [])
+    public function runCommand(array $argv = []): void
     {
         $input = new CommandCall($argv);
 
@@ -165,11 +207,14 @@ class App
     }
 
     /**
+     * run single
+     *
      * @param CommandCall $input
      * @throws CommandNotFoundException
+     *
      * @return bool
      */
-    protected function runSingle(CommandCall $input)
+    protected function runSingle(CommandCall $input): bool
     {
         try {
             $callable = $this->commandRegistry->getCallable($input->command);

--- a/src/Command/CommandCall.php
+++ b/src/Command/CommandCall.php
@@ -2,8 +2,6 @@
 
 namespace Minicli\Command;
 
-use Assets\Command\Test\ParamsController;
-
 class CommandCall
 {
     /** @var string  */
@@ -16,7 +14,7 @@ class CommandCall
     public $args = [];
 
     /** @var array  */
-    public $raw_args = [];
+    public $rawArgs = [];
 
     /** @var array */
     public $params = [];
@@ -30,7 +28,7 @@ class CommandCall
      */
     public function __construct(array $argv)
     {
-        $this->raw_args = $argv;
+        $this->rawArgs = $argv;
         $this->parseCommand($argv);
 
         $this->command = isset($this->args[1]) ? $this->args[1] : null;
@@ -93,7 +91,7 @@ class CommandCall
      */
     public function getRawArgs()
     {
-        return $this->raw_args;
+        return $this->rawArgs;
     }
 
     /**

--- a/src/Command/CommandCall.php
+++ b/src/Command/CommandCall.php
@@ -1,34 +1,62 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Command;
 
 class CommandCall
 {
-    /** @var string  */
-    public $command;
+    /**
+     * command
+     *
+     * @param string|null $command
+     */
+    public ?string $command;
 
-    /** @var string */
-    public $subcommand;
+     /**
+     * sub command
+     *
+     * @param string $subcommand
+     */
+    public string $subcommand;
 
-    /** @var array */
-    public $args = [];
+    /**
+     * arguments
+     *
+     * @param array $args
+     */
+    public array $args = [];
 
-    /** @var array  */
-    public $rawArgs = [];
+     /**
+     * raw arguments
+     *
+     * @param array $rawArgs
+     */
+    public array $rawArgs = [];
 
-    /** @var array */
-    public $params = [];
+    /**
+     * parameters
+     *
+     * @param array $params
+     */
+    public array $params = [];
 
-    /** @var array  */
-    public $flags = [];
+    /**
+     * flags
+     *
+     * @param array $flags
+     */
+    public array $flags = [];
 
     /**
      * CommandCall constructor.
+     *
      * @param array $argv
      */
     public function __construct(array $argv)
     {
         $this->rawArgs = $argv;
+
         $this->parseCommand($argv);
 
         $this->command = isset($this->args[1]) ? $this->args[1] : null;
@@ -36,7 +64,13 @@ class CommandCall
         $this->subcommand = isset($this->args[2]) ? $this->args[2] : 'default';
     }
 
-    protected function parseCommand($argv)
+    /**
+     * parse command
+     *
+     * @param array $argv
+     * @return void
+     */
+    protected function parseCommand(array $argv): void
     {
         foreach ($argv as $arg) {
             $pair = explode('=', $arg);
@@ -56,19 +90,23 @@ class CommandCall
     }
 
     /**
+     * check has parameter
+     *
      * @param string $param
      * @return bool
      */
-    public function hasParam($param)
+    public function hasParam(string $param): bool
     {
         return isset($this->params[$param]);
     }
 
     /**
+     * check has flag
+     *
      * @param string $flag
      * @return bool
      */
-    public function hasFlag($flag)
+    public function hasFlag(string $flag): bool
     {
         if (in_array($flag, $this->flags)) {
             return true;
@@ -78,26 +116,32 @@ class CommandCall
     }
 
     /**
+     * get parameter
+     *
      * @param string $param
      * @return string|null
      */
-    public function getParam($param)
+    public function getParam(string $param): ?string
     {
         return $this->hasParam($param) ? $this->params[$param] : null;
     }
 
     /**
+     * get raw args
+     *
      * @return array
      */
-    public function getRawArgs()
+    public function getRawArgs(): array
     {
         return $this->rawArgs;
     }
 
     /**
+     * get flags
+     *
      * @return array
      */
-    public function getFlags()
+    public function getFlags(): array
     {
         return $this->flags;
     }

--- a/src/Command/CommandCall.php
+++ b/src/Command/CommandCall.php
@@ -13,11 +13,11 @@ class CommandCall
      */
     public ?string $command;
 
-     /**
-     * sub command
-     *
-     * @param string $subcommand
-     */
+    /**
+    * sub command
+    *
+    * @param string $subcommand
+    */
     public string $subcommand;
 
     /**
@@ -27,11 +27,11 @@ class CommandCall
      */
     public array $args = [];
 
-     /**
-     * raw arguments
-     *
-     * @param array $rawArgs
-     */
+    /**
+    * raw arguments
+    *
+    * @param array $rawArgs
+    */
     public array $rawArgs = [];
 
     /**

--- a/src/Command/CommandController.php
+++ b/src/Command/CommandController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Command;
 
 use Minicli\App;
@@ -8,31 +10,45 @@ use Minicli\Output\OutputHandler;
 
 abstract class CommandController implements ControllerInterface
 {
-    /** @var  App */
-    protected $app;
-
-    /** @var  CommandCall */
-    protected $input;
-
     /**
-     * Command Logic.
-     * @return void
-     */
-    abstract public function handle();
-
-    /**
-     * Called before `run`.
+     * app instance.
+     *
      * @param App $app
      */
-    public function boot(App $app)
+    protected App $app;
+
+    /**
+     * command call instance.
+     *
+     * @param CommandCall $input
+     */
+    protected CommandCall $input;
+
+    /**
+     * handle command.
+     *
+     * @return void
+     */
+    abstract public function handle(): void;
+
+    /**
+     * Called before `run`
+     *
+     * @param App $app
+     * @return void
+     */
+    public function boot(App $app): void
     {
         $this->app = $app;
     }
 
     /**
-     * @param CommandCall $input
+     * run command
+     *
+     * @param App $app
+     * @return void
      */
-    public function run(CommandCall $input)
+    public function run(CommandCall $input): void
     {
         $this->input = $input;
         $this->handle();
@@ -40,68 +56,82 @@ abstract class CommandController implements ControllerInterface
 
     /**
      * Called when `run` is successfully finished.
+     *
      * @return void
      */
-    public function teardown()
+    public function teardown(): void
     {
-        //
     }
 
     /**
+     * get arguments
+     *
      * @return array
      */
-    protected function getArgs()
+    protected function getArgs(): array
     {
         return $this->input->args;
     }
 
     /**
+     * get parameters
+     *
      * @return array
      */
-    protected function getParams()
+    protected function getParams(): array
     {
         return $this->input->params;
     }
 
     /**
+     * check has parameter
+     *
      * @param string $param
      * @return bool
      */
-    protected function hasParam($param)
+    protected function hasParam(string $param): bool
     {
         return $this->input->hasParam($param);
     }
 
     /**
+     * check has flag
+     *
      * @param string $flag
      * @return bool
      */
-    protected function hasFlag($flag)
+    protected function hasFlag(string $flag): bool
     {
         return $this->input->hasFlag($flag);
     }
 
     /**
-     * @param $param
-     * @return null
+     * get parameter
+     *
+     * @param string $param
+     * @return string|null
      */
-    protected function getParam($param)
+    protected function getParam($param): ?string
     {
         return $this->input->getParam($param);
     }
 
     /**
+     * get app instance
+     *
      * @return App
      */
-    protected function getApp()
+    protected function getApp(): App
     {
         return $this->app;
     }
 
     /**
+     * get output handler instance
+     *
      * @return OutputHandler
      */
-    protected function getPrinter()
+    protected function getPrinter(): OutputHandler
     {
         return $this->getApp()->getPrinter();
     }

--- a/src/Command/CommandNamespace.php
+++ b/src/Command/CommandNamespace.php
@@ -1,36 +1,51 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Minicli\Command;
 
 class CommandNamespace
 {
-    /** @var  string */
-    protected $name;
-
-    /** @var array  */
-    protected $controllers = [];
-
     /**
-     * CommandNamespace constructor.
+     * name
+     *
      * @param string $name
      */
-    public function __construct($name)
+    protected string $name;
+
+    /**
+     * controllers
+     *
+     * @param array $controllers
+     */
+    protected array $controllers = [];
+
+    /**
+     * CommandNamespace constructor
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
     /**
-     * @return mixed
+     * get name
+     *
+     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
      * Load namespace controllers
+     *
      * @return array
      */
-    public function loadControllers($commandsPath)
+    public function loadControllers(string $commandsPath): array
     {
         foreach (glob($commandsPath . '/' . $this->getName() . '/*Controller.php') as $controllerFile) {
             $this->loadCommandMap($controllerFile);
@@ -40,39 +55,50 @@ class CommandNamespace
     }
 
     /**
+     * get controllers
+     *
      * @return array
      */
-    public function getControllers()
+    public function getControllers(): array
     {
         return $this->controllers;
     }
 
     /**
-     * @param $commandName
-     * @return CommandController
+     * @param string $commandName
+     *
+     * @return CommandController|null
      */
-    public function getController($commandName)
+    public function getController(string $commandName): ?CommandController
     {
         return isset($this->controllers[$commandName]) ? $this->controllers[$commandName] : null;
     }
 
     /**
+     * load command map
+     *
      * @param string $controllerFile
+     * @return void
      */
-    protected function loadCommandMap($controllerFile)
+    protected function loadCommandMap(string $controllerFile): void
     {
         $filename = basename($controllerFile);
 
         $controllerClass = str_replace('.php', '', $filename);
         $commandName = strtolower(str_replace('Controller', '', $controllerClass));
-        $full_class_name = sprintf("%s\\%s", $this->getNamespace($controllerFile), $controllerClass);
+        $fullClassName = sprintf("%s\\%s", $this->getNamespace($controllerFile), $controllerClass);
 
-        /** @var CommandController $controller */
-        $controller = new $full_class_name();
+        $controller = new $fullClassName();
         $this->controllers[$commandName] = $controller;
     }
 
-    protected function getNamespace($filename)
+    /**
+     * get namespace
+     *
+     * @param string $filename
+     * @return string
+     */
+    protected function getNamespace(string $filename): string
     {
         $lines = preg_grep('/^namespace /', file($filename));
         $namespaceLine = trim(array_shift($lines));

--- a/src/Command/CommandNamespace.php
+++ b/src/Command/CommandNamespace.php
@@ -30,10 +30,10 @@ class CommandNamespace
      * Load namespace controllers
      * @return array
      */
-    public function loadControllers($commands_path)
+    public function loadControllers($commandsPath)
     {
-        foreach (glob($commands_path . '/' . $this->getName() . '/*Controller.php') as $controller_file) {
-            $this->loadCommandMap($controller_file);
+        foreach (glob($commandsPath . '/' . $this->getName() . '/*Controller.php') as $controllerFile) {
+            $this->loadCommandMap($controllerFile);
         }
 
         return $this->getControllers();
@@ -48,36 +48,36 @@ class CommandNamespace
     }
 
     /**
-     * @param $command_name
+     * @param $commandName
      * @return CommandController
      */
-    public function getController($command_name)
+    public function getController($commandName)
     {
-        return isset($this->controllers[$command_name]) ? $this->controllers[$command_name] : null;
+        return isset($this->controllers[$commandName]) ? $this->controllers[$commandName] : null;
     }
 
     /**
-     * @param string $controller_file
+     * @param string $controllerFile
      */
-    protected function loadCommandMap($controller_file)
+    protected function loadCommandMap($controllerFile)
     {
-        $filename = basename($controller_file);
+        $filename = basename($controllerFile);
 
-        $controller_class = str_replace('.php', '', $filename);
-        $command_name = strtolower(str_replace('Controller', '', $controller_class));
-        $full_class_name = sprintf("%s\\%s", $this->getNamespace($controller_file), $controller_class);
+        $controllerClass = str_replace('.php', '', $filename);
+        $commandName = strtolower(str_replace('Controller', '', $controllerClass));
+        $full_class_name = sprintf("%s\\%s", $this->getNamespace($controllerFile), $controllerClass);
 
         /** @var CommandController $controller */
         $controller = new $full_class_name();
-        $this->controllers[$command_name] = $controller;
+        $this->controllers[$commandName] = $controller;
     }
 
     protected function getNamespace($filename)
     {
         $lines = preg_grep('/^namespace /', file($filename));
-        $namespace_line = trim(array_shift($lines));
+        $namespaceLine = trim(array_shift($lines));
         $match = [];
-        preg_match('/^namespace (.*);$/', $namespace_line, $match);
+        preg_match('/^namespace (.*);$/', $namespaceLine, $match);
 
         return array_pop($match);
     }

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -128,7 +128,7 @@ class CommandRegistry implements ServiceInterface
      * @param string $subcommand
      * @return CommandController|null
      */
-    public function getCallableController(string $command,string $subcommand = "default"): ?CommandController
+    public function getCallableController(string $command, string $subcommand = "default"): ?CommandController
     {
         $namespace = $this->getNamespace($command);
 

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -1,40 +1,63 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Command;
 
 use Minicli\App;
-use Minicli\Exception\CommandNotFoundException;
 use Minicli\ServiceInterface;
+use Minicli\Exception\CommandNotFoundException;
 
 class CommandRegistry implements ServiceInterface
 {
-    /** @var string */
-    protected $commandsPath;
-
-    /** @var array */
-    protected $namespaces = [];
-
-    /** @var array */
-    protected $defaultRegistry = [];
-
     /**
-     * CommandRegistry constructor.
+     * commands path
+     *
      * @param string $commandsPath
      */
-    public function __construct($commandsPath)
+    protected string $commandsPath;
+
+    /**
+     * namespaces
+     *
+     * @param array $namespaces
+     */
+    protected array $namespaces = [];
+
+    /**
+     * default registry
+     *
+     * @param array $defaultRegistry
+     */
+    protected array $defaultRegistry = [];
+
+    /**
+     * CommandRegistry constructor
+     *
+     * @param string $commandsPath
+     */
+    public function __construct(string $commandsPath)
     {
         $this->commandsPath = $commandsPath;
     }
 
-    public function load(App $app)
+    /**
+     * load app
+     *
+     * @param App $app
+     * @return void
+     */
+    public function load(App $app): void
     {
         $this->autoloadNamespaces();
     }
 
     /**
+     * autoload namespaces
+     *
      * @return void
      */
-    public function autoloadNamespaces()
+    public function autoloadNamespaces(): void
     {
         foreach (glob($this->getCommandsPath() . '/*', GLOB_ONLYDIR) as $namespacePath) {
             $this->registerNamespace(basename($namespacePath));
@@ -42,10 +65,12 @@ class CommandRegistry implements ServiceInterface
     }
 
     /**
+     * register namespace
+     *
      * @param string $commandNamespace
      * @return void
      */
-    public function registerNamespace($commandNamespace)
+    public function registerNamespace(string $commandNamespace): void
     {
         $namespace = new CommandNamespace($commandNamespace);
         $namespace->loadControllers($this->getCommandsPath());
@@ -53,47 +78,57 @@ class CommandRegistry implements ServiceInterface
     }
 
     /**
+     * get namespace
+     *
      * @param string $command
      * @return CommandNamespace
      */
-    public function getNamespace($command)
+    public function getNamespace(string $command): ?CommandNamespace
     {
         return isset($this->namespaces[$command]) ? $this->namespaces[$command] : null;
     }
 
     /**
+     * get commands path
+     *
      * @return string
      */
-    public function getCommandsPath()
+    public function getCommandsPath(): string
     {
         return $this->commandsPath;
     }
 
     /**
-     * Registers an anonymous function as single command.
+     * Registers an anonymous function as single command
+     *
      * @param string $name
      * @param callable $callable
+     * @return void
      */
-    public function registerCommand($name, $callable)
+    public function registerCommand(string $name, callable $callable): void
     {
         $this->defaultRegistry[$name] = $callable;
     }
 
     /**
+     * get command
+     *
      * @param string $command
      * @return callable|null
      */
-    public function getCommand($command)
+    public function getCommand(string $command): ?callable
     {
         return isset($this->defaultRegistry[$command]) ? $this->defaultRegistry[$command] : null;
     }
 
     /**
+     * get callable controller
+     *
      * @param string $command
      * @param string $subcommand
-     * @return CommandController | null
+     * @return CommandController|null
      */
-    public function getCallableController($command, $subcommand = "default")
+    public function getCallableController(string $command,string $subcommand = "default"): ?CommandController
     {
         $namespace = $this->getNamespace($command);
 
@@ -105,24 +140,29 @@ class CommandRegistry implements ServiceInterface
     }
 
     /**
+     * get callable
+     *
      * @param string $command
      * @return callable|null
-     * @throws \Exception
+     *
+     * @throws \CommandNotFoundException
      */
-    public function getCallable($command)
+    public function getCallable(string $command): ?callable
     {
-        $single_command = $this->getCommand($command);
-        if ($single_command === null) {
+        $singleCommand = $this->getCommand($command);
+        if ($singleCommand === null) {
             throw new CommandNotFoundException(sprintf("Command \"%s\" not found.", $command));
         }
 
-        return $single_command;
+        return $singleCommand;
     }
 
     /**
+     * get command map
+     *
      * @return array
      */
-    public function getCommandMap()
+    public function getCommandMap(): array
     {
         $map = [];
 
@@ -130,10 +170,6 @@ class CommandRegistry implements ServiceInterface
             $map[$command] = $callback;
         }
 
-        /**
-         * @var  string $command
-         * @var  CommandNamespace $namespace
-         */
         foreach ($this->namespaces as $command => $namespace) {
             $controllers = $namespace->getControllers();
             $subs = [];

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -9,21 +9,21 @@ use Minicli\ServiceInterface;
 class CommandRegistry implements ServiceInterface
 {
     /** @var string */
-    protected $commands_path;
+    protected $commandsPath;
 
     /** @var array */
     protected $namespaces = [];
 
     /** @var array */
-    protected $default_registry = [];
+    protected $defaultRegistry = [];
 
     /**
      * CommandRegistry constructor.
-     * @param string $commands_path
+     * @param string $commandsPath
      */
-    public function __construct($commands_path)
+    public function __construct($commandsPath)
     {
-        $this->commands_path = $commands_path;
+        $this->commandsPath = $commandsPath;
     }
 
     public function load(App $app)
@@ -36,20 +36,20 @@ class CommandRegistry implements ServiceInterface
      */
     public function autoloadNamespaces()
     {
-        foreach (glob($this->getCommandsPath() . '/*', GLOB_ONLYDIR) as $namespace_path) {
-            $this->registerNamespace(basename($namespace_path));
+        foreach (glob($this->getCommandsPath() . '/*', GLOB_ONLYDIR) as $namespacePath) {
+            $this->registerNamespace(basename($namespacePath));
         }
     }
 
     /**
-     * @param string $command_namespace
+     * @param string $commandNamespace
      * @return void
      */
-    public function registerNamespace($command_namespace)
+    public function registerNamespace($commandNamespace)
     {
-        $namespace = new CommandNamespace($command_namespace);
+        $namespace = new CommandNamespace($commandNamespace);
         $namespace->loadControllers($this->getCommandsPath());
-        $this->namespaces[strtolower($command_namespace)] = $namespace;
+        $this->namespaces[strtolower($commandNamespace)] = $namespace;
     }
 
     /**
@@ -66,7 +66,7 @@ class CommandRegistry implements ServiceInterface
      */
     public function getCommandsPath()
     {
-        return $this->commands_path;
+        return $this->commandsPath;
     }
 
     /**
@@ -76,7 +76,7 @@ class CommandRegistry implements ServiceInterface
      */
     public function registerCommand($name, $callable)
     {
-        $this->default_registry[$name] = $callable;
+        $this->defaultRegistry[$name] = $callable;
     }
 
     /**
@@ -85,7 +85,7 @@ class CommandRegistry implements ServiceInterface
      */
     public function getCommand($command)
     {
-        return isset($this->default_registry[$command]) ? $this->default_registry[$command] : null;
+        return isset($this->defaultRegistry[$command]) ? $this->defaultRegistry[$command] : null;
     }
 
     /**
@@ -126,7 +126,7 @@ class CommandRegistry implements ServiceInterface
     {
         $map = [];
 
-        foreach ($this->default_registry as $command => $callback) {
+        foreach ($this->defaultRegistry as $command => $callback) {
             $map[$command] = $callback;
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,14 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli;
 
 class Config implements ServiceInterface
 {
-    /** @var  array */
-    protected $config;
+    /**
+     * config array
+     *
+     * @var array
+     */
+    protected array $config;
 
     /**
-     * Config constructor.
+     * Config constructor
+     *
      * @param array $config
      */
     public function __construct(array $config = [])
@@ -17,30 +24,45 @@ class Config implements ServiceInterface
     }
 
     /**
+     * get config
+     *
      * @param string $name
-     * @return string|null
+     * @return mixed
      */
-    public function __get($name)
+    public function __get(string $name): mixed
     {
         return isset($this->config[$name]) ? $this->config[$name] : null;
     }
 
     /**
+     * set config
+     *
      * @param string $name
      * @param string $value
      */
-    public function __set($name, $value)
+    public function __set(string $name, string $value): void
     {
         $this->config[$name] = $value;
     }
 
-    public function has($name)
+    /**
+     * check if has config
+     *
+     * @param  string $name
+     * @return boolean
+     */
+    public function has(string $name): bool
     {
         return isset($this->config[$name]);
     }
 
-    public function load(App $app)
+    /**
+     * load application instance
+     *
+     * @param App $app
+     * @return void
+     */
+    public function load(App $app): void
     {
-        return null;
     }
 }

--- a/src/ControllerInterface.php
+++ b/src/ControllerInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Minicli;
 
 use Minicli\Command\CommandCall;
@@ -7,19 +10,24 @@ interface ControllerInterface
 {
     /**
      * Called before `run`
+     *
      * @param App $app
+     * @return void
      */
-    public function boot(App $app);
+    public function boot(App $app): void;
 
     /**
      * Main execution
+     *
      * @param CommandCall $input
-     */
-    public function run(CommandCall $input);
-
-    /**
-     * Called when `run` is successfully finished.
      * @return void
      */
-    public function teardown();
+    public function run(CommandCall $input): void;
+
+    /**
+     * Called when `run` is successfully finished
+     *
+     * @return void
+     */
+    public function teardown(): void;
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -1,19 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli;
 
 use RuntimeException;
 
 class Input
 {
-    /** @var array  */
-    protected $inputHistory = [];
-
-    /** @var string */
-    protected $prompt;
+    /**
+     * input history
+     *
+     * @var array
+     */
+    protected array $inputHistory = [];
 
     /**
-     * @throws RuntimeException if the readline extension is not loaded.
+     * prompt
+     *
+     * @var string
+     */
+    protected string $prompt;
+
+    /**
+     * constructor
+     *
+     * @param string $prompt
      */
     public function __construct($prompt = 'minicli$> ')
     {
@@ -22,9 +34,11 @@ class Input
     }
 
     /**
-     * @throws RuntimeException if the readline extension is not loaded.
+     * read input
+     *
+     * @return string
      */
-    public function read()
+    public function read(): string
     {
         $this->checkReadlineExtension();
         $input = readline($this->getPrompt());
@@ -34,33 +48,43 @@ class Input
     }
 
     /**
+     * get input history
+     *
      * @return array
      */
-    public function getInputHistory()
+    public function getInputHistory(): array
     {
         return $this->inputHistory;
     }
 
     /**
+     * get prompt
+     *
      * @return string
      */
-    public function getPrompt()
+    public function getPrompt(): string
     {
         return $this->prompt;
     }
 
     /**
+     * set prompt
+     *
      * @param string $prompt
+     * @return void
      */
-    public function setPrompt(string $prompt)
+    public function setPrompt(string $prompt): void
     {
         $this->prompt = $prompt;
     }
 
     /**
-     * @throws RuntimeException if the readline extension is not loaded.
+     * check read line extension
+     *
+     * @return void
+     * @throws RuntimeException
      */
-    private function checkReadlineExtension()
+    private function checkReadlineExtension(): void
     {
         if (extension_loaded('readline')) {
             return;

--- a/src/Input.php
+++ b/src/Input.php
@@ -7,7 +7,7 @@ use RuntimeException;
 class Input
 {
     /** @var array  */
-    protected $input_history = [];
+    protected $inputHistory = [];
 
     /** @var string */
     protected $prompt;
@@ -28,7 +28,7 @@ class Input
     {
         $this->checkReadlineExtension();
         $input = readline($this->getPrompt());
-        $this->input_history[] = $input;
+        $this->inputHistory[] = $input;
 
         return $input;
     }
@@ -38,7 +38,7 @@ class Input
      */
     public function getInputHistory()
     {
-        return $this->input_history;
+        return $this->inputHistory;
     }
 
     /**

--- a/src/Output/Adapter/DefaultPrinterAdapter.php
+++ b/src/Output/Adapter/DefaultPrinterAdapter.php
@@ -1,13 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output\Adapter;
 
 use Minicli\Output\PrinterAdapterInterface;
 
 class DefaultPrinterAdapter implements PrinterAdapterInterface
 {
-    public function out($message)
+    /**
+     * output
+     *
+     * @param string $message
+     * @return string
+     */
+    public function out(string $message): string
     {
-        echo $message;
+        return $message;
     }
 }

--- a/src/Output/Adapter/FilePrinterAdapter.php
+++ b/src/Output/Adapter/FilePrinterAdapter.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Minicli\Output\Adapter;
 
@@ -19,13 +20,14 @@ class FilePrinterAdapter implements PrinterAdapterInterface
         $this->outputFile = $outputFile;
     }
 
-    /**
-     * Writes output to file.
-     * @param string $message
-     * @param null $style
-     * @return bool
-     */
-    public function out($message, $style = null)
+   /**
+    * writes output to file
+    *
+    * @param string $message
+    * @param string|null $style
+    * @return string
+    */
+    public function out(string $message, ?string $style = null): string
     {
         $fp = fopen($this->outputFile, "a+");
         fwrite($fp, $message);

--- a/src/Output/Adapter/FilePrinterAdapter.php
+++ b/src/Output/Adapter/FilePrinterAdapter.php
@@ -24,13 +24,13 @@ class FilePrinterAdapter implements PrinterAdapterInterface
         $this->outputFile = $outputFile;
     }
 
-   /**
-    * writes output to file
-    *
-    * @param string $message
-    * @param string|null $style
-    * @return string
-    */
+    /**
+     * writes output to file
+     *
+     * @param string $message
+     * @param string|null $style
+     * @return string
+     */
     public function out(string $message, ?string $style = null): string
     {
         $fp = fopen($this->outputFile, "a+");

--- a/src/Output/Adapter/FilePrinterAdapter.php
+++ b/src/Output/Adapter/FilePrinterAdapter.php
@@ -8,15 +8,15 @@ use Minicli\Output\PrinterAdapterInterface;
 class FilePrinterAdapter implements PrinterAdapterInterface
 {
     /** @var string */
-    protected $output_file;
+    protected $outputFile;
 
     /**
      * FilePrinterAdapter constructor.
-     * @param $output_file
+     * @param $outputFile
      */
-    public function __construct($output_file)
+    public function __construct($outputFile)
     {
-        $this->output_file = $output_file;
+        $this->outputFile = $outputFile;
     }
 
     /**
@@ -27,7 +27,7 @@ class FilePrinterAdapter implements PrinterAdapterInterface
      */
     public function out($message, $style = null)
     {
-        $fp = fopen($this->output_file, "a+");
+        $fp = fopen($this->outputFile, "a+");
         fwrite($fp, $message);
         fclose($fp);
 

--- a/src/Output/Adapter/FilePrinterAdapter.php
+++ b/src/Output/Adapter/FilePrinterAdapter.php
@@ -8,14 +8,18 @@ use Minicli\Output\PrinterAdapterInterface;
 
 class FilePrinterAdapter implements PrinterAdapterInterface
 {
-    /** @var string */
-    protected $outputFile;
+    /**
+     * output file
+     *
+     * @var string
+     */
+    protected string $outputFile;
 
     /**
-     * FilePrinterAdapter constructor.
-     * @param $outputFile
+     * setup file printer adapter
+     * @param string $outputFile
      */
-    public function __construct($outputFile)
+    public function __construct(string $outputFile)
     {
         $this->outputFile = $outputFile;
     }

--- a/src/Output/CLIColors.php
+++ b/src/Output/CLIColors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output;
 
 class CLIColors

--- a/src/Output/CLIThemeInterface.php
+++ b/src/Output/CLIThemeInterface.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output;
 
 interface CLIThemeInterface
 {
     /**
      * Obtains the colors that compose a style for that theme, such as "error" or "success"
+     *
      * @param string $name The name of the style
      * @return array An array containing FG color and optionally BG color
      */
-    public function getStyle(string $name);
+    public function getStyle(string $name): array;
 }

--- a/src/Output/Filter/ColorOutputFilter.php
+++ b/src/Output/Filter/ColorOutputFilter.php
@@ -58,13 +58,13 @@ class ColorOutputFilter implements OutputFilterInterface
      */
     public function format($message, $style = "default"): string
     {
-        $style_colors = $this->theme->getStyle($style);
+        $styleColors = $this->theme->getStyle($style);
 
         $bg = '';
-        if (isset($style_colors[1])) {
-            $bg = ';' . $style_colors[1];
+        if (isset($styleColors[1])) {
+            $bg = ';' . $styleColors[1];
         }
 
-        return sprintf("\e[%s%sm%s\e[0m", $style_colors[0], $bg, $message);
+        return sprintf("\e[%s%sm%s\e[0m", $styleColors[0], $bg, $message);
     }
 }

--- a/src/Output/Filter/ColorOutputFilter.php
+++ b/src/Output/Filter/ColorOutputFilter.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Minicli\Output\Filter;
 
@@ -9,11 +10,16 @@ use Minicli\Output\Theme\DefaultTheme;
 
 class ColorOutputFilter implements OutputFilterInterface
 {
-    /** @var CLIThemeInterface */
-    protected $theme;
+    /**
+     * theme
+     *
+     * @var CLIThemeInterface
+     */
+    protected CLIThemeInterface $theme;
 
     /**
-     * ColorOutputFilter constructor.
+     * ColorOutputFilter constructor
+     *
      * @param CLIThemeInterface|null $theme If a theme is not set, the default CLITheme will be used.
      */
     public function __construct(CLIThemeInterface $theme = null)
@@ -23,6 +29,7 @@ class ColorOutputFilter implements OutputFilterInterface
 
     /**
      * Gets the CLITheme
+     *
      * @return CLIThemeInterface
      */
     public function getTheme(): CLIThemeInterface
@@ -32,7 +39,9 @@ class ColorOutputFilter implements OutputFilterInterface
 
     /**
      * Sets the CLITheme
+     *
      * @param CLIThemeInterface $theme
+     * @return void
      */
     public function setTheme(CLIThemeInterface $theme): void
     {
@@ -41,22 +50,24 @@ class ColorOutputFilter implements OutputFilterInterface
 
     /**
      * Filters a string according to the specified style.
+     *
      * @param string $message
-     * @param string $style
+     * @param string|null $style
      * @return string the resulting string
      */
-    public function filter($message, $style = "default"): string
+    public function filter(string $message, ?string $style = "default"): string
     {
         return $this->format($message, $style);
     }
 
     /**
      * Formats a message with color codes based on a CLITheme
+     *
      * @param string $message
      * @param string $style
      * @return string
      */
-    public function format($message, $style = "default"): string
+    public function format(string $message, string $style = "default"): string
     {
         $styleColors = $this->theme->getStyle($style);
 

--- a/src/Output/Filter/SimpleOutputFilter.php
+++ b/src/Output/Filter/SimpleOutputFilter.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Minicli\Output\Filter;
 
@@ -7,7 +8,14 @@ use Minicli\Output\OutputFilterInterface;
 
 class SimpleOutputFilter implements OutputFilterInterface
 {
-    public function filter($message, $style = null)
+    /**
+     * simple filter
+     *
+     * @param string $message
+     * @param string|null $style
+     * @return string
+     */
+    public function filter(string $message, ?string $style = null): string
     {
         return $message;
     }

--- a/src/Output/Filter/TimestampOutputFilter.php
+++ b/src/Output/Filter/TimestampOutputFilter.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Minicli\Output\Filter;
 
@@ -8,12 +9,13 @@ use Minicli\Output\OutputFilterInterface;
 class TimestampOutputFilter implements OutputFilterInterface
 {
     /**
-     * Adds timestamp to the message
+     * adds timestamp to the message
+     *
      * @param string $message
-     * @param null $style
+     * @param string|null $style
      * @return string
      */
-    public function filter($message, $style = null)
+    public function filter(string $message, ?string $style = null): string
     {
         $datetime = new \DateTime();
         return $datetime->format('[Y-m-d H:i:S]') . $message;

--- a/src/Output/Helper/TableHelper.php
+++ b/src/Output/Helper/TableHelper.php
@@ -9,13 +9,13 @@ use Minicli\Output\OutputFilterInterface;
 class TableHelper
 {
     /** @var array */
-    protected $table_rows;
+    protected $tableRows;
 
     /** @var array */
-    protected $styled_rows;
+    protected $styledRows;
 
     /** @var string */
-    protected $formatted_table;
+    protected $formattedTable;
 
     /**
      * TableHelper constructor. Optionally sets the table rows with an array containing all rows.
@@ -34,7 +34,7 @@ class TableHelper
      */
     public function totalRows() : int
     {
-        return count($this->table_rows);
+        return count($this->tableRows);
     }
 
     /**
@@ -85,14 +85,14 @@ class TableHelper
     {
         $filter = $filter ?? new SimpleOutputFilter();
 
-        foreach ($this->styled_rows as $index => $item) {
+        foreach ($this->styledRows as $index => $item) {
             $style = $item['style'];
             $row = $this->getRowAsString($item['row']);
 
-            $this->formatted_table .= "\n" . $filter->filter($row, $style);
+            $this->formattedTable .= "\n" . $filter->filter($row, $style);
         }
 
-        return $this->formatted_table;
+        return $this->formattedTable;
     }
 
     /**
@@ -102,62 +102,62 @@ class TableHelper
      */
     protected function insertTableRow(array $row, $style = 'default')
     {
-        $this->table_rows[] = $row;
-        $this->styled_rows[] = [ 'row' => $row, 'style' => $style ];
+        $this->tableRows[] = $row;
+        $this->styledRows[] = [ 'row' => $row, 'style' => $style ];
     }
 
     /**
      * Calculates ideal column sizes for the current table rows
-     * @param int $min_col_size
+     * @param int $minColSize
      * @return array
      */
-    protected function calculateColumnSizes($min_col_size = 5): array
+    protected function calculateColumnSizes($minColSize = 5): array
     {
-        $column_sizes = [];
+        $columnSizes = [];
 
-        foreach ($this->table_rows as $row_number => $row_content) {
-            $column_count = 0;
+        foreach ($this->tableRows as $rowNumber => $rowContent) {
+            $columnCount = 0;
 
-            foreach ($row_content as $cell) {
-                $column_sizes[$column_count] = $column_sizes[$column_count] ?? $min_col_size;
-                if (strlen($cell) >= $column_sizes[$column_count]) {
-                    $column_sizes[$column_count] = strlen($cell) + 2;
+            foreach ($rowContent as $cell) {
+                $columnSizes[$columnCount] = $columnSizes[$columnCount] ?? $minColSize;
+                if (strlen($cell) >= $columnSizes[$columnCount]) {
+                    $columnSizes[$columnCount] = strlen($cell) + 2;
                 }
-                $column_count++;
+                $columnCount++;
             }
         }
-        
-        return $column_sizes;
+
+        return $columnSizes;
     }
 
     /**
      * Transforms a row into a formatted string, with adequate column sizing
      * @param array $row
-     * @param int $col_size
+     * @param int $colSize
      * @return string
      */
-    protected function getRowAsString(array $row, $col_size = 5): string
+    protected function getRowAsString(array $row, $colSize = 5): string
     {
         //first, determine the size of each column
-        $column_sizes = $this->calculateColumnSizes();
+        $columnSizes = $this->calculateColumnSizes();
 
-        $formatted_row = "";
+        $formattedRow = "";
 
-        foreach ($row as $column => $table_cell) {
-            $formatted_row .= $this->getPaddedString($table_cell, $column_sizes[$column]);
+        foreach ($row as $column => $tableCell) {
+            $formattedRow .= $this->getPaddedString($tableCell, $columnSizes[$column]);
         }
 
-        return $formatted_row;
+        return $formattedRow;
     }
 
     /**
      * Pads a string as table cell
-     * @param string $table_cell
-     * @param int $col_size
+     * @param string $tableCell
+     * @param int $colSize
      * @return string
      */
-    protected function getPaddedString($table_cell, $col_size = 5): string
+    protected function getPaddedString($tableCell, $colSize = 5): string
     {
-        return str_pad($table_cell, $col_size);
+        return str_pad($tableCell, $colSize);
     }
 }

--- a/src/Output/Helper/TableHelper.php
+++ b/src/Output/Helper/TableHelper.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Minicli\Output\Helper;
 
@@ -8,20 +9,33 @@ use Minicli\Output\OutputFilterInterface;
 
 class TableHelper
 {
-    /** @var array */
-    protected $tableRows;
-
-    /** @var array */
-    protected $styledRows;
-
-    /** @var string */
-    protected $formattedTable;
+    /**
+     * table rows
+     *
+     * @var array
+     */
+    protected array $tableRows;
 
     /**
-     * TableHelper constructor. Optionally sets the table rows with an array containing all rows.
+     * style rows
+     *
+     * @var array
+     */
+    protected array $styledRows;
+
+    /**
+     * formatted table
+     *
+     * @var string
+     */
+    protected string $formattedTable = '';
+
+    /**
+     * TableHelper constructor. Optionally sets the table rows with an array containing all rows
+     *
      * @param array|null $table
      */
-    public function __construct(array $table = null)
+    public function __construct(?array $table = null)
     {
         if (is_array($table)) {
             $this->setTable($table);
@@ -30,17 +44,20 @@ class TableHelper
 
     /**
      * Returns the total number of rows in the table
+     *
      * @return int
      */
-    public function totalRows() : int
+    public function totalRows(): int
     {
         return count($this->tableRows);
     }
 
     /**
      * Adds a table header
+     *
      * @param array $header
      * @param string $style
+     * @return void
      */
     public function addHeader(array $header, $style = 'alt'): void
     {
@@ -49,7 +66,9 @@ class TableHelper
 
     /**
      * Sets the table rows at once
+     *
      * @param array $full_table An array containing each table row. Rows must be arrays containing the individual cell contents.
+     * @return void
      */
     public function setTable(array $full_table): void
     {
@@ -68,20 +87,23 @@ class TableHelper
 
     /**
      * Adds a table row
+     *
      * @param array $row
      * @param string $style
+     * @return void
      */
-    public function addRow(array $row, $style = 'default'): void
+    public function addRow(array $row, string $style = 'default'): void
     {
         $this->insertTableRow($row, $style);
     }
 
     /**
      * Returns the formatted table for printing
+     *
      * @param OutputFilterInterface $filter In case no filter is provided, a SimpleOutputFilter is used by default.
      * @return string
      */
-    public function getFormattedTable(OutputFilterInterface $filter = null)
+    public function getFormattedTable(OutputFilterInterface $filter = null): string
     {
         $filter = $filter ?? new SimpleOutputFilter();
 
@@ -97,10 +119,12 @@ class TableHelper
 
     /**
      * Inserts a new row in the table and sets the style for that row
+     *
      * @param array $row
      * @param string $style
+     * @return void
      */
-    protected function insertTableRow(array $row, $style = 'default')
+    protected function insertTableRow(array $row, string $style = 'default'): void
     {
         $this->tableRows[] = $row;
         $this->styledRows[] = [ 'row' => $row, 'style' => $style ];
@@ -108,10 +132,11 @@ class TableHelper
 
     /**
      * Calculates ideal column sizes for the current table rows
+     *
      * @param int $minColSize
      * @return array
      */
-    protected function calculateColumnSizes($minColSize = 5): array
+    protected function calculateColumnSizes(int $minColSize = 5): array
     {
         $columnSizes = [];
 
@@ -132,15 +157,15 @@ class TableHelper
 
     /**
      * Transforms a row into a formatted string, with adequate column sizing
+     *
      * @param array $row
      * @param int $colSize
      * @return string
      */
-    protected function getRowAsString(array $row, $colSize = 5): string
+    protected function getRowAsString(array $row, int $colSize = 5): string
     {
         //first, determine the size of each column
-        $columnSizes = $this->calculateColumnSizes();
-
+        $columnSizes  = $this->calculateColumnSizes();
         $formattedRow = "";
 
         foreach ($row as $column => $tableCell) {
@@ -152,11 +177,12 @@ class TableHelper
 
     /**
      * Pads a string as table cell
+     *
      * @param string $tableCell
      * @param int $colSize
      * @return string
      */
-    protected function getPaddedString($tableCell, $colSize = 5): string
+    protected function getPaddedString(string $tableCell, int $colSize = 5): string
     {
         return str_pad($tableCell, $colSize);
     }

--- a/src/Output/Helper/ThemeHelper.php
+++ b/src/Output/Helper/ThemeHelper.php
@@ -1,16 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output\Helper;
 
 use Minicli\Output\Filter\ColorOutputFilter;
 
 class ThemeHelper
 {
-    /** @var array */
-    protected $theme = '';
+    /**
+     * theme
+     *
+     * @var string
+     */
+    protected string $theme = '';
 
     /**
-     * ThemeHelper constructor. Takes in the App theme config value.
+     * ThemeHelper constructor. Takes in the App theme config value
+     *
      * @param string $themeConfig
      */
     public function __construct(string $themeConfig = '')
@@ -20,10 +27,11 @@ class ThemeHelper
     }
 
     /**
-     * Initialize and return an OutputFilter based on our theme class.
+     * Initialize and return an OutputFilter based on our theme class
+     *
      * @return ColorOutPutFilter
      */
-    public function getOutputFilter()
+    public function getOutputFilter(): ColorOutPutFilter
     {
         if (class_exists($this->theme)) {
             return new ColorOutputFilter(new $this->theme());
@@ -34,9 +42,11 @@ class ThemeHelper
 
     /**
      * Parses the theme config setting and returns a namespaced class name.
+     *
+     * @param string $themeConfig
      * @return string
      */
-    protected function parseThemeSetting($themeConfig)
+    protected function parseThemeSetting(string $themeConfig): string
     {
         if (!$themeConfig) {
             return '';

--- a/src/Output/Helper/ThemeHelper.php
+++ b/src/Output/Helper/ThemeHelper.php
@@ -11,11 +11,11 @@ class ThemeHelper
 
     /**
      * ThemeHelper constructor. Takes in the App theme config value.
-     * @param string $theme_config
+     * @param string $themeConfig
      */
-    public function __construct(string $theme_config = '')
+    public function __construct(string $themeConfig = '')
     {
-        $this->theme = $this->parseThemeSetting($theme_config);
+        $this->theme = $this->parseThemeSetting($themeConfig);
         return $this;
     }
 
@@ -36,16 +36,16 @@ class ThemeHelper
      * Parses the theme config setting and returns a namespaced class name.
      * @return string
      */
-    protected function parseThemeSetting($theme_config)
+    protected function parseThemeSetting($themeConfig)
     {
-        if (!$theme_config) {
+        if (!$themeConfig) {
             return '';
         }
 
-        if ($theme_config[0] == '\\') {
-            return '\Minicli\Output\Theme' . $theme_config . 'Theme';  // Built-in theme.
+        if ($themeConfig[0] == '\\') {
+            return '\Minicli\Output\Theme' . $themeConfig . 'Theme';  // Built-in theme.
         }
 
-        return $theme_config . 'Theme'; // User-defined theme.
+        return $themeConfig . 'Theme'; // User-defined theme.
     }
 }

--- a/src/Output/OutputFilterInterface.php
+++ b/src/Output/OutputFilterInterface.php
@@ -1,9 +1,17 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Minicli\Output;
 
 interface OutputFilterInterface
 {
-    public function filter($message, $style = null);
+    /**
+     * output filter
+     *
+     * @param string $message
+     * @param string|null $style
+     * @return string
+     */
+    public function filter(string $message, ?string $style = null): string;
 }

--- a/src/Output/OutputHandler.php
+++ b/src/Output/OutputHandler.php
@@ -10,10 +10,10 @@ use Minicli\ServiceInterface;
 class OutputHandler implements ServiceInterface
 {
     /** @var PrinterAdapterInterface */
-    protected $printer_adapter;
+    protected $printerAdapter;
 
     /** @var array */
-    protected $output_filters = [];
+    protected $outputFilters = [];
 
     /**
      * OutputHandler constructor.
@@ -21,7 +21,7 @@ class OutputHandler implements ServiceInterface
      */
     public function __construct(PrinterAdapterInterface $printer = null)
     {
-        $this->printer_adapter = $printer ?? new DefaultPrinterAdapter();
+        $this->printerAdapter = $printer ?? new DefaultPrinterAdapter();
     }
 
     /**
@@ -29,7 +29,7 @@ class OutputHandler implements ServiceInterface
      */
     public function registerFilter(OutputFilterInterface $filter): void
     {
-        $this->output_filters[] = $filter;
+        $this->outputFilters[] = $filter;
     }
 
     /**
@@ -37,7 +37,7 @@ class OutputHandler implements ServiceInterface
      */
     public function clearFilters(): void
     {
-        $this->output_filters = [];
+        $this->outputFilters = [];
     }
 
     /**
@@ -59,7 +59,7 @@ class OutputHandler implements ServiceInterface
     {
         /** @var OutputFilterInterface $filter */
 
-        foreach ($this->output_filters as $filter) {
+        foreach ($this->outputFilters as $filter) {
             $content = $filter->filter($content, $style);
         }
 
@@ -73,7 +73,7 @@ class OutputHandler implements ServiceInterface
      */
     public function out($content, $style = "default"): void
     {
-        $this->printer_adapter->out($this->filterOutput($content, $style));
+        $this->printerAdapter->out($this->filterOutput($content, $style));
     }
 
     /**
@@ -82,7 +82,7 @@ class OutputHandler implements ServiceInterface
      */
     public function rawOutput($content)
     {
-        $this->printer_adapter->out($content);
+        $this->printerAdapter->out($content);
     }
 
     /**
@@ -153,7 +153,7 @@ class OutputHandler implements ServiceInterface
     {
         $helper = new TableHelper($table);
 
-        $filter = (isset($this->output_filters[0]) && $this->output_filters[0] instanceof OutputFilterInterface) ? $this->output_filters[0] : null;
+        $filter = (isset($this->outputFilters[0]) && $this->outputFilters[0] instanceof OutputFilterInterface) ? $this->outputFilters[0] : null;
         $this->newline();
         $this->rawOutput($helper->getFormattedTable($filter));
         $this->newline();

--- a/src/Output/OutputHandler.php
+++ b/src/Output/OutputHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output;
 
 use Minicli\App;
@@ -9,23 +11,35 @@ use Minicli\ServiceInterface;
 
 class OutputHandler implements ServiceInterface
 {
-    /** @var PrinterAdapterInterface */
-    protected $printerAdapter;
-
-    /** @var array */
-    protected $outputFilters = [];
+    /**
+     * printer adapter
+     *
+     * @var PrinterAdapterInterface
+     */
+    protected PrinterAdapterInterface $printerAdapter;
 
     /**
-     * OutputHandler constructor.
-     * @param PrinterAdapterInterface $printer
+     * output filters
+     *
+     * @var array
      */
-    public function __construct(PrinterAdapterInterface $printer = null)
+    protected array $outputFilters = [];
+
+    /**
+     * OutputHandler constructor
+     *
+     * @param PrinterAdapterInterface|null $printer
+     */
+    public function __construct(?PrinterAdapterInterface $printer = null)
     {
         $this->printerAdapter = $printer ?? new DefaultPrinterAdapter();
     }
 
     /**
+     * register filter
+     *
      * @param OutputFilterInterface $filter
+     * @return void
      */
     public function registerFilter(OutputFilterInterface $filter): void
     {
@@ -33,7 +47,9 @@ class OutputHandler implements ServiceInterface
     }
 
     /**
-     * Removes all filters.
+     * clear registered filters
+     *
+     * @return void
      */
     public function clearFilters(): void
     {
@@ -41,24 +57,24 @@ class OutputHandler implements ServiceInterface
     }
 
     /**
+     * load application instance
+     *
      * @param App $app
-     * @return bool
+     * @return void
      */
-    public function load(App $app)
+    public function load(App $app): void
     {
-        return true;
     }
 
     /**
-     * Pass content through current configured filter(s).
-     * @param string $content
-     * @param string $style
+     * Pass content through current configured filter(s)
+     *
+     * @param  string $content
+     * @param  string|null $style
      * @return string
      */
-    public function filterOutput($content, $style = null): string
+    public function filterOutput(string $content, ?string $style = null): string
     {
-        /** @var OutputFilterInterface $filter */
-
         foreach ($this->outputFilters as $filter) {
             $content = $filter->filter($content, $style);
         }
@@ -68,25 +84,30 @@ class OutputHandler implements ServiceInterface
 
     /**
      * Prints a content using configured filters
+     *
      * @param string $content
      * @param string $style
      */
-    public function out($content, $style = "default"): void
+    public function out(string $content, string $style = "default"): void
     {
-        $this->printerAdapter->out($this->filterOutput($content, $style));
+        print $this->printerAdapter->out($this->filterOutput($content, $style));
     }
 
     /**
      * Prints content without formatting or styling
+     *
      * @param string $content
+     * @return void
      */
-    public function rawOutput($content)
+    public function rawOutput(string $content): void
     {
-        $this->printerAdapter->out($content);
+        print $this->printerAdapter->out($content);
     }
 
     /**
-     * Prints a new line.
+     * prints a new line
+     *
+     * @return void
      */
     public function newline(): void
     {
@@ -95,11 +116,12 @@ class OutputHandler implements ServiceInterface
 
     /**
      * Displays content using the "default" style
+     *
      * @param string $content
      * @param bool $alt Whether or not to use the inverted style ("alt")
      * @return void
      */
-    public function display($content, $alt = false): void
+    public function display(string $content, bool $alt = false): void
     {
         $this->newline();
         $this->out($content, $alt ? "alt" : "default");
@@ -108,11 +130,12 @@ class OutputHandler implements ServiceInterface
 
     /**
      * Prints content using the "error" style
+     *
      * @param string $content
      * @param bool $alt Whether or not to use the inverted style ("error_alt")
      * @return void
      */
-    public function error($content, $alt = false): void
+    public function error(string $content, bool $alt = false): void
     {
         $this->newline();
         $this->out($content, $alt ? "error_alt" : "error");
@@ -121,11 +144,12 @@ class OutputHandler implements ServiceInterface
 
     /**
      * Prints content using the "info" style
+     *
      * @param string $content
      * @param bool $alt Whether or not to use the inverted style ("info_alt")
      * @return void
      */
-    public function info($content, $alt = false): void
+    public function info(string $content, bool $alt = false): void
     {
         $this->newline();
         $this->out($content, $alt ? "info_alt" : "info");
@@ -134,11 +158,12 @@ class OutputHandler implements ServiceInterface
 
     /**
      * Prints content using the "success" style
+     *
      * @param string $content The string to print
      * @param bool $alt Whether or not to use the inverted style ("success_alt")
      * @return void
      */
-    public function success($content, $alt = false): void
+    public function success(string $content, bool $alt = false): void
     {
         $this->newline();
         $this->out($content, $alt ? "success_alt" : "success");
@@ -147,6 +172,7 @@ class OutputHandler implements ServiceInterface
 
     /**
      * Shortcut method to print tables using the TableHelper
+     *
      * @param array $table An array containing all table rows. Each row must be an array with the individual cells.
      */
     public function printTable(array $table): void

--- a/src/Output/PrinterAdapterInterface.php
+++ b/src/Output/PrinterAdapterInterface.php
@@ -1,9 +1,16 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Minicli\Output;
 
 interface PrinterAdapterInterface
 {
-    public function out($message);
+    /**
+     * output method
+     *
+     * @param string $message
+     * @return string
+     */
+    public function out(string $message): string;
 }

--- a/src/Output/Theme/DaltonTheme.php
+++ b/src/Output/Theme/DaltonTheme.php
@@ -1,11 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output\Theme;
 
 use Minicli\Output\CLIColors;
 
 class DaltonTheme extends DefaultTheme
 {
+    /**
+     * get the colors
+     *
+     * @return array
+     */
     public function getThemeColors(): array
     {
         return [

--- a/src/Output/Theme/DefaultTheme.php
+++ b/src/Output/Theme/DefaultTheme.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output\Theme;
 
 use Minicli\Output\CLIColors;
@@ -7,8 +9,12 @@ use Minicli\Output\CLIThemeInterface;
 
 class DefaultTheme implements CLIThemeInterface
 {
-    /** @var array $styles  */
-    public $styles = [];
+    /**
+     * styles
+     *
+     * @var array
+     */
+    public array $styles = [];
 
     /**
      * DefaultTheme constructor.
@@ -24,6 +30,7 @@ class DefaultTheme implements CLIThemeInterface
 
     /**
      * Obtains the colors that compose a style for that theme, such as "error" or "success"
+     *
      * @param string $style_name
      * @return array An array containing FG color and optionally BG color
      */
@@ -34,6 +41,7 @@ class DefaultTheme implements CLIThemeInterface
 
     /**
      * Sets a style
+     *
      * @param string $name
      * @param array $style
      */
@@ -43,7 +51,9 @@ class DefaultTheme implements CLIThemeInterface
     }
 
     /**
-     * Returns the default style colors
+     * get default style colors
+     *
+     * @return array
      */
     public function getDefaultColors(): array
     {
@@ -65,7 +75,8 @@ class DefaultTheme implements CLIThemeInterface
     }
 
     /**
-     * This method should be implemented by children themes to overwrite and set custom styles/colors.
+     * This method should be implemented by children themes to overwrite and set custom styles/colors
+     *
      * @return array
      */
     public function getThemeColors(): array

--- a/src/Output/Theme/UnicornTheme.php
+++ b/src/Output/Theme/UnicornTheme.php
@@ -1,11 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli\Output\Theme;
 
 use Minicli\Output\CLIColors;
 
 class UnicornTheme extends DefaultTheme
 {
+    /**
+     * get theme colors
+     *
+     * @return array
+     */
     public function getThemeColors(): array
     {
         return [

--- a/src/ServiceInterface.php
+++ b/src/ServiceInterface.php
@@ -1,8 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Minicli;
 
 interface ServiceInterface
 {
-    public function load(App $app);
+    /**
+     * load application
+     *
+     * @param App $app
+     * @return void
+     */
+    public function load(App $app): void;
 }

--- a/tests/Assets/Command/Test/DefaultController.php
+++ b/tests/Assets/Command/Test/DefaultController.php
@@ -6,7 +6,7 @@ use Minicli\Command\CommandController;
 
 class DefaultController extends CommandController
 {
-    public function handle()
+    public function handle(): void
     {
         $this->getPrinter()->rawOutput('test default');
     }

--- a/tests/Assets/Command/Test/HelpController.php
+++ b/tests/Assets/Command/Test/HelpController.php
@@ -6,7 +6,7 @@ use Minicli\Command\CommandController;
 
 class HelpController extends CommandController
 {
-    public function handle()
+    public function handle(): void
     {
         $name = "default";
 

--- a/tests/Assets/Command/Test/ParamsController.php
+++ b/tests/Assets/Command/Test/ParamsController.php
@@ -6,7 +6,7 @@ use Minicli\Command\CommandController;
 
 class ParamsController extends CommandController
 {
-    public function handle()
+    public function handle(): void
     {
         $print = count($this->getArgs());
 

--- a/tests/Assets/Command/Test/TableController.php
+++ b/tests/Assets/Command/Test/TableController.php
@@ -7,7 +7,7 @@ use Minicli\Output\Helper\TableHelper;
 
 class TableController extends CommandController
 {
-    public function handle()
+    public function handle(): void
     {
         $table = new TableHelper();
 
@@ -19,6 +19,6 @@ class TableController extends CommandController
             ]);
         }
 
-        return $table->getFormattedTable();
+        $table->getFormattedTable();
     }
 }

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -95,17 +95,9 @@ it('asserts App throws exception when command is not callable', function () {
 
 $app = new \Minicli\App();
 $errorNotFound = $app->getPrinter()->filterOutput("Command \"inexistent-command\" not found.", 'error');
-$errorNotCallable = $app->getPrinter()->filterOutput("The registered command is not a callable function.", 'error');
 
 it('asserts App shows error when debug is set to false and command is not found', function () {
     $app = getProdApp();
 
     $app->runCommand(['minicli', 'inexistent-command']);
 })->expectOutputString("\n" . $errorNotFound . "\n");
-
-it('asserts App shows error when debug is set to false and command is not callable', function () {
-    $app = getProdApp();
-    $app->registerCommand('minicli-test-error', "not a callable");
-
-    $app->runCommand(['minicli', 'minicli-test-error']);
-})->expectOutputString("\n" . $errorNotCallable . "\n");

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -91,9 +91,7 @@ it('asserts App throws exception when single command is not found', function () 
 it('asserts App throws exception when command is not callable', function () {
     $app = getBasicApp();
     $app->registerCommand('minicli-test-error', "not a callable");
-
-    $app->runCommand(['minicli', 'minicli-test-error']);
-})->expectException(CommandNotFoundException::class);
+})->expectException(\TypeError::class);
 
 $app = new \Minicli\App();
 $errorNotFound = $app->getPrinter()->filterOutput("Command \"inexistent-command\" not found.", 'error');

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -35,7 +35,7 @@ it('asserts App has Config Service', function () {
 it('asserts App has CommandRegistry Service', function () {
     $app = getBasicApp();
 
-    $registry = $app->command_registry;
+    $registry = $app->commandRegistry;
 
     $this->assertTrue($registry instanceof CommandRegistry);
 });
@@ -63,7 +63,7 @@ it('asserts App registers and executes single command', function () {
         $app->getPrinter()->rawOutput("testing minicli");
     });
 
-    $command = $app->command_registry->getCallable('minicli-test');
+    $command = $app->commandRegistry->getCallable('minicli-test');
     $this->assertIsCallable($command);
 
     $app->runCommand(['minicli', 'minicli-test']);
@@ -96,18 +96,18 @@ it('asserts App throws exception when command is not callable', function () {
 })->expectException(CommandNotFoundException::class);
 
 $app = new \Minicli\App();
-$error_not_found = $app->getPrinter()->filterOutput("Command \"inexistent-command\" not found.", 'error');
-$error_not_callable = $app->getPrinter()->filterOutput("The registered command is not a callable function.", 'error');
+$errorNotFound = $app->getPrinter()->filterOutput("Command \"inexistent-command\" not found.", 'error');
+$errorNotCallable = $app->getPrinter()->filterOutput("The registered command is not a callable function.", 'error');
 
 it('asserts App shows error when debug is set to false and command is not found', function () {
     $app = getProdApp();
 
     $app->runCommand(['minicli', 'inexistent-command']);
-})->expectOutputString("\n" . $error_not_found . "\n");
+})->expectOutputString("\n" . $errorNotFound . "\n");
 
 it('asserts App shows error when debug is set to false and command is not callable', function () {
     $app = getProdApp();
     $app->registerCommand('minicli-test-error', "not a callable");
 
     $app->runCommand(['minicli', 'minicli-test-error']);
-})->expectOutputString("\n" . $error_not_callable . "\n");
+})->expectOutputString("\n" . $errorNotCallable . "\n");

--- a/tests/Feature/Command/CommandRegistryTest.php
+++ b/tests/Feature/Command/CommandRegistryTest.php
@@ -54,7 +54,7 @@ it('asserts Registry throws CommandNotFoundException when a command is not found
 it('assets Registry returns full command list', function () {
     $registry = getRegistry();
 
-    $command_list = $registry->getCommandMap();
-    $this->assertCount(2, $command_list);
-    $this->assertCount(4, $command_list['test']);
+    $commandList = $registry->getCommandMap();
+    $this->assertCount(2, $commandList);
+    $this->assertCount(4, $commandList['test']);
 });

--- a/tests/Feature/InputTest.php
+++ b/tests/Feature/InputTest.php
@@ -6,6 +6,6 @@ it('asserts that Input sets a default prompt', function () {
     $input = new Input();
 
     $this->assertEquals('minicli$> ', $input->getPrompt());
-})->skip(static function (): bool {
+})->skip(function (): bool {
     return ! extension_loaded('readline');
 }, 'Extension readline is required.');

--- a/tests/Feature/Output/CLIThemeTest.php
+++ b/tests/Feature/Output/CLIThemeTest.php
@@ -19,9 +19,9 @@ it('asserts that Default CLI theme sets all default styles', function () {
 });
 
 it('asserts that default theme returns expected colors for default text', function () {
-    $theme_default = new DefaultTheme();
+    $themeDefault = new DefaultTheme();
 
-    $this->assertContains(CLIColors::$FG_WHITE, $theme_default->getStyle('default'));
+    $this->assertContains(CLIColors::$FG_WHITE, $themeDefault->getStyle('default'));
 });
 
 it('asserts that Unicorn CLI theme sets all default styles', function () {

--- a/tests/Feature/Output/ColorOutputTest.php
+++ b/tests/Feature/Output/ColorOutputTest.php
@@ -90,10 +90,10 @@ it('asserts that its possible to overwrite default styles', function () {
     $printer = getColorOutputHandler();
     $printer->clearFilters();
 
-    $my_custom_theme = new DefaultTheme();
-    $my_custom_theme->setStyle('default', [CLIColors::$FG_MAGENTA]);
+    $myCustomTheme = new DefaultTheme();
+    $myCustomTheme->setStyle('default', [CLIColors::$FG_MAGENTA]);
 
-    $printer->registerFilter(new ColorOutputFilter($my_custom_theme));
+    $printer->registerFilter(new ColorOutputFilter($myCustomTheme));
     $printer->display("custom theme");
 })->expectOutputString("\n" . getThemedOutput("custom theme"). "\n");
 
@@ -101,10 +101,10 @@ it('asserts that custom styles can be used with the out method', function () {
     $printer = getColorOutputHandler();
     $printer->clearFilters();
 
-    $my_custom_theme = new DefaultTheme();
-    $my_custom_theme->setStyle('custom', [CLIColors::$FG_MAGENTA]);
+    $myCustomTheme = new DefaultTheme();
+    $myCustomTheme->setStyle('custom', [CLIColors::$FG_MAGENTA]);
 
-    $printer->registerFilter(new ColorOutputFilter($my_custom_theme));
+    $printer->registerFilter(new ColorOutputFilter($myCustomTheme));
     $printer->out("custom theme", 'custom');
 })->expectOutputString(getThemedOutput("custom theme"));
 

--- a/tests/Feature/Output/FilePrinterAdapterTest.php
+++ b/tests/Feature/Output/FilePrinterAdapterTest.php
@@ -11,8 +11,8 @@ it('asserts that FilePrinterAdapter saves content to file', function () {
         @unlink($file_path);
     }
 
-    $fileprinter = new FilePrinterAdapter($file_path);
-    $output = new OutputHandler($fileprinter);
+    $filePrinter = new FilePrinterAdapter($file_path);
+    $output = new OutputHandler($filePrinter);
 
     $output->rawOutput("writing output to file");
 
@@ -23,8 +23,8 @@ it('asserts that FilePrinterAdapter saves content to file', function () {
 it('asserts that FilePrinterAdapter throws exception when a non-writable file is provided', function () {
     $file_path = '/root/cant_write_here';
 
-    $fileprinter = new FilePrinterAdapter($file_path);
-    $output = new OutputHandler($fileprinter);
+    $filePrinter = new FilePrinterAdapter($file_path);
+    $output = new OutputHandler($filePrinter);
 
     $output->rawOutput("writing output to file");
 })->expectException(ErrorException::class);

--- a/tests/Feature/Output/TableHelperTest.php
+++ b/tests/Feature/Output/TableHelperTest.php
@@ -9,14 +9,14 @@ it('asserts that TableHelper creates table from constructor', function () {
     ];
 
 
-    $table_helper = new TableHelper($table);
+    $tableHelper = new TableHelper($table);
 
-    $this->assertEquals(2, $table_helper->totalRows());
-    $table_content = $table_helper->getFormattedTable();
+    $this->assertEquals(2, $tableHelper->totalRows());
+    $tableContent = $tableHelper->getFormattedTable();
 
-    $this->assertStringContainsString('value1', $table_content);
-    $this->assertStringContainsString('value2', $table_content);
-    $this->assertStringContainsString('value3', $table_content);
+    $this->assertStringContainsString('value1', $tableContent);
+    $this->assertStringContainsString('value2', $tableContent);
+    $this->assertStringContainsString('value3', $tableContent);
 });
 
 it('asserts that TableHelper sets and outputs table rows', function () {
@@ -33,11 +33,11 @@ it('asserts that TableHelper sets and outputs table rows', function () {
     }
 
     $this->assertEquals(11, $table->totalRows());
-    $table_content = $table->getFormattedTable();
+    $tableContent = $table->getFormattedTable();
 
-    $this->assertStringContainsString('ID', $table_content);
-    $this->assertStringContainsString('NAME', $table_content);
-    $this->assertStringContainsString('FIELD3', $table_content);
+    $this->assertStringContainsString('ID', $tableContent);
+    $this->assertStringContainsString('NAME', $tableContent);
+    $this->assertStringContainsString('FIELD3', $tableContent);
 });
 
 it('asserts that all fields respect column sizes', function () {
@@ -48,12 +48,12 @@ it('asserts that all fields respect column sizes', function () {
     ];
 
 
-    $table_helper = new TableHelper($table);
-    $table_content = $table_helper->getFormattedTable();
+    $tableHelper = new TableHelper($table);
+    $tableContent = $tableHelper->getFormattedTable();
 
-    $rows = explode("\n", $table_content);
-    $size_at_first = strlen($rows[1]);
-    $size_at_last = strlen($rows[count($rows)-1]);
+    $rows = explode("\n", $tableContent);
+    $sizeAtFirst = strlen($rows[1]);
+    $sizeAtLast = strlen($rows[count($rows)-1]);
 
-    $this->assertSame($size_at_first, $size_at_last);
+    $this->assertSame($sizeAtFirst, $sizeAtLast);
 });

--- a/tests/Feature/Output/TableHelperTest.php
+++ b/tests/Feature/Output/TableHelperTest.php
@@ -28,7 +28,9 @@ it('asserts that TableHelper sets and outputs table rows', function () {
 
     for ($i = 1; $i <= 10; $i++) {
         $table->addRow([
-            $i, 'test', rand(0, 200)
+           (string) $i,
+           'test',
+           (string) rand(0, 200)
         ]);
     }
 

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -55,7 +55,7 @@ function getRegistry()
     });
 
     /** @var CommandRegistry $registry */
-    $registry = $app->command_registry;
+    $registry = $app->commandRegistry;
 
     return $registry;
 }


### PR DESCRIPTION
Hi @erikaheidi PHP **7.3** has reached the end of support and php **7.4** will reach it in [november ](https://www.php.net/eol.php) 
I think its time to switch minicli to **PHP 8** and use the new provided features.
Therefore i have invested sometime upgrading minicli to PHP 8 and clean up code little bit 
Here is a list of what was updated : 
- php version to 8 
- fixed failing tests 
- added type hints & return type hints (stricter = safer)
- use consistent variable namings CamelCases instead of underscores
- added dockblocks (all classes properties and methods are well commented)
- upgrade csfixer to version 3.5
- added composer scripts 

Let me know what you think. 
Any suggestions modifications from all contributors are much appreciated.