### PR TITLE
Fixing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
         <img src="https://readthedocs.org/projects/minicliphp/badge/?version=latest" alt="Documentation Status" title="Documentation Status">
     </a>
     <h1 align="center">
-        Minicli 2
+        Minicli 3
     </h1>
 </p>
 <br>
@@ -28,6 +28,7 @@ Quick links:
 - [Documentation](https://docs.minicli.dev)
 - [Demos](https://github.com/minicli/demos)
 - [Contributing](CONTRIBUTING.md)
+- [Contributors](CONTRIBUTORS.md)
 
 ## Dependency-free: What Does it Mean
 
@@ -207,7 +208,3 @@ The following tutorials on [dev.to](https://dev.to/erikaheidi) compose a series 
  - Part 4: [Introducing minicli: a microframework for CLI-centric PHP applications](https://dev.to/erikaheidi/introducing-minicli-a-microframework-for-cli-centric-php-applications-44ik)
 
 _Note: Minicli has evolved a lot since that series was initially written, but that was the base for what Minicli is today._
-
-## Created with Minicli
-
-- [Dolphin](https://github.com/do-community/dolphin) - a CLI tool for managing DigitalOcean servers with Ansible.

--- a/src/Command/CommandCall.php
+++ b/src/Command/CommandCall.php
@@ -59,9 +59,9 @@ class CommandCall
 
         $this->parseCommand($argv);
 
-        $this->command = isset($this->args[1]) ? $this->args[1] : null;
+        $this->command = $this->args[1] ?? null;
 
-        $this->subcommand = isset($this->args[2]) ? $this->args[2] : 'default';
+        $this->subcommand = $this->args[2] ?? 'default';
     }
 
     /**

--- a/src/Command/CommandController.php
+++ b/src/Command/CommandController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Minicli\Command;
 
+use JetBrains\PhpStorm\Pure;
 use Minicli\App;
 use Minicli\ControllerInterface;
 use Minicli\Output\OutputHandler;
@@ -44,8 +45,7 @@ abstract class CommandController implements ControllerInterface
 
     /**
      * run command
-     *
-     * @param App $app
+     * @param CommandCall $input
      * @return void
      */
     public function run(CommandCall $input): void
@@ -111,7 +111,7 @@ abstract class CommandController implements ControllerInterface
      * @param string $param
      * @return string|null
      */
-    protected function getParam($param): ?string
+    protected function getParam(string $param): ?string
     {
         return $this->input->getParam($param);
     }

--- a/src/Command/CommandNamespace.php
+++ b/src/Command/CommandNamespace.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Minicli\Command;
 
+use Minicli\ControllerInterface;
+
 class CommandNamespace
 {
     /**
@@ -67,11 +69,11 @@ class CommandNamespace
     /**
      * @param string $commandName
      *
-     * @return CommandController|null
+     * @return ControllerInterface|null
      */
-    public function getController(string $commandName): ?CommandController
+    public function getController(string $commandName): ?ControllerInterface
     {
-        return isset($this->controllers[$commandName]) ? $this->controllers[$commandName] : null;
+        return $this->controllers[$commandName] ?? null;
     }
 
     /**

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Minicli\Command;
 
 use Minicli\App;
+use Minicli\ControllerInterface;
 use Minicli\ServiceInterface;
 use Minicli\Exception\CommandNotFoundException;
 
@@ -81,11 +82,11 @@ class CommandRegistry implements ServiceInterface
      * get namespace
      *
      * @param string $command
-     * @return CommandNamespace
+     * @return ?CommandNamespace
      */
     public function getNamespace(string $command): ?CommandNamespace
     {
-        return isset($this->namespaces[$command]) ? $this->namespaces[$command] : null;
+        return $this->namespaces[$command] ?? null;
     }
 
     /**
@@ -118,7 +119,7 @@ class CommandRegistry implements ServiceInterface
      */
     public function getCommand(string $command): ?callable
     {
-        return isset($this->defaultRegistry[$command]) ? $this->defaultRegistry[$command] : null;
+        return $this->defaultRegistry[$command] ?? null;
     }
 
     /**
@@ -126,9 +127,9 @@ class CommandRegistry implements ServiceInterface
      *
      * @param string $command
      * @param string $subcommand
-     * @return CommandController|null
+     * @return ControllerInterface|null
      */
-    public function getCallableController(string $command, string $subcommand = "default"): ?CommandController
+    public function getCallableController(string $command, string $subcommand = "default"): ?ControllerInterface
     {
         $namespace = $this->getNamespace($command);
 
@@ -145,7 +146,7 @@ class CommandRegistry implements ServiceInterface
      * @param string $command
      * @return callable|null
      *
-     * @throws \CommandNotFoundException
+     * @throws CommandNotFoundException
      */
     public function getCallable(string $command): ?callable
     {


### PR DESCRIPTION
Fixed an issue that I flagged in another project after upgrading, the return type for the `getController` method was set to CommandController, but it should be set to the ControllerInterface.

Other small fixtures.