### PR TITLE
#39 Support to multiple command source directories

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -47,7 +47,11 @@ class App
         ], $config);
 
         $this->addService('config', new Config($config));
-        $this->addService('commandRegistry', new CommandRegistry($this->config->app_path));
+        $commandsPath = $this->config->app_path;
+        if (!is_array($commandsPath)) {
+            $commandsPath = [ $commandsPath ];
+        }
+        $this->addService('commandRegistry', new CommandRegistry($commandsPath));
 
         $this->setSignature($signature);
         $this->setTheme($this->config->theme);

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -14,9 +14,9 @@ class CommandRegistry implements ServiceInterface
     /**
      * commands path
      *
-     * @param string $commandsPath
+     * @param array $commandsPath
      */
-    protected string $commandsPath;
+    protected array $commandsPath;
 
     /**
      * namespaces
@@ -35,9 +35,9 @@ class CommandRegistry implements ServiceInterface
     /**
      * CommandRegistry constructor
      *
-     * @param string $commandsPath
+     * @param array $commandsPath
      */
-    public function __construct(string $commandsPath)
+    public function __construct(array $commandsPath)
     {
         $this->commandsPath = $commandsPath;
     }
@@ -50,18 +50,21 @@ class CommandRegistry implements ServiceInterface
      */
     public function load(App $app): void
     {
-        $this->autoloadNamespaces();
+        foreach ($this->getCommandsPath() as $commandSource) {
+            $this->autoloadNamespaces($commandSource);
+        }
     }
 
     /**
      * autoload namespaces
      *
+     * @param string $commandSource
      * @return void
      */
-    public function autoloadNamespaces(): void
+    public function autoloadNamespaces(string $commandSource): void
     {
-        foreach (glob($this->getCommandsPath() . '/*', GLOB_ONLYDIR) as $namespacePath) {
-            $this->registerNamespace(basename($namespacePath));
+        foreach (glob($commandSource . '/*', GLOB_ONLYDIR) as $namespacePath) {
+            $this->registerNamespace(basename($namespacePath), $commandSource);
         }
     }
 
@@ -69,12 +72,13 @@ class CommandRegistry implements ServiceInterface
      * register namespace
      *
      * @param string $commandNamespace
+     * @param string $commandSource
      * @return void
      */
-    public function registerNamespace(string $commandNamespace): void
+    public function registerNamespace(string $commandNamespace, string $commandSource): void
     {
         $namespace = new CommandNamespace($commandNamespace);
-        $namespace->loadControllers($this->getCommandsPath());
+        $namespace->loadControllers($commandSource);
         $this->namespaces[strtolower($commandNamespace)] = $namespace;
     }
 
@@ -92,9 +96,9 @@ class CommandRegistry implements ServiceInterface
     /**
      * get commands path
      *
-     * @return string
+     * @return array
      */
-    public function getCommandsPath(): string
+    public function getCommandsPath(): array
     {
         return $this->commandsPath;
     }

--- a/tests/Assets/VendorCommand/Vendor/DefaultController.php
+++ b/tests/Assets/VendorCommand/Vendor/DefaultController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Assets\VendorCommand\Vendor;
+
+use Minicli\Command\CommandController;
+
+class DefaultController extends CommandController
+{
+    public function handle(): void
+    {
+        $this->getPrinter()->rawOutput('test vendor');
+    }
+}

--- a/tests/Feature/Command/CommandRegistryTest.php
+++ b/tests/Feature/Command/CommandRegistryTest.php
@@ -11,6 +11,17 @@ it('asserts Registry autoloads command namespaces', function () {
     $this->assertTrue($namespace instanceof CommandNamespace);
 });
 
+it('asserts Registry autoloads command namespaces in multiple source paths', function () {
+    $registry = getRegistryWithMultiplePaths();
+    $namespace1 = $registry->getNamespace("test");
+    $namespace2 = $registry->getNamespace("vendor");
+
+    $this->assertNotNull($namespace1);
+    $this->assertNotNull($namespace2);
+    $this->assertTrue($namespace1 instanceof CommandNamespace);
+    $this->assertTrue($namespace2 instanceof CommandNamespace);
+});
+
 it('asserts Registry returns null when a namespace is not found', function () {
     $registry = getRegistry();
     $namespace = $registry->getNamespace("dasdsad");
@@ -57,4 +68,13 @@ it('assets Registry returns full command list', function () {
     $commandList = $registry->getCommandMap();
     $this->assertCount(2, $commandList);
     $this->assertCount(4, $commandList['test']);
+});
+
+it('assets Registry returns full command list when with multiple command sources', function () {
+    $registry = getRegistryWithMultiplePaths();
+
+    $commandList = $registry->getCommandMap();
+    $this->assertCount(2, $commandList);
+    $this->assertCount(4, $commandList['test']);
+    $this->assertCount(1, $commandList['vendor']);
 });

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -59,3 +59,20 @@ function getRegistry()
 
     return $registry;
 }
+
+function getRegistryWithMultiplePaths()
+{
+    $config = [
+        'app_path' => [
+            getCommandsPath(),
+            __DIR__ . '/Assets/VendorCommand'
+        ]
+    ];
+
+    $app = new App($config);
+
+    /** @var CommandRegistry $registry */
+    $registry = $app->commandRegistry;
+
+    return $registry;
+}


### PR DESCRIPTION
This PR introduces support to multiple command source directories. With this change, it is possible to pass an array of paths instead of a single string to the config, and the autoloader will pick up command namespaces from all configured paths.

Strings are still allowed as we added a check to make sure we transform them into arrays before registering the command registry service. So no backwards compatibility issues.

The motivation behind this update is to allow commands to be shared and reused more easily, which in turn will facilitate extending Minicli. 