### PR TITLE
Easier config for 3rd party commands

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -37,6 +37,7 @@ class App
      * App constructor
      *
      * @param array $config
+     * @param string $signature
      */
     public function __construct(array $config = [], string $signature = './minicli help')
     {
@@ -51,10 +52,32 @@ class App
         if (!is_array($commandsPath)) {
             $commandsPath = [ $commandsPath ];
         }
-        $this->addService('commandRegistry', new CommandRegistry($commandsPath));
+
+        $commandSources = [];
+        foreach ($commandsPath as $path) {
+            if (str_starts_with($path, '@')) {
+                $path = str_replace('@', $this->getAppRoot() . '/vendor/', $path) . '/Command';
+            }
+            $commandSources[] = $path;
+        }
+        $this->addService('commandRegistry', new CommandRegistry($commandSources));
 
         $this->setSignature($signature);
         $this->setTheme($this->config->theme);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAppRoot(): string
+    {
+        $root_app = dirname(__DIR__);
+
+        if (!is_file($root_app . '/vendor/autoload.php')) {
+            $root_app = dirname(__DIR__, 4);
+        }
+
+        return $root_app;
     }
 
     /**

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -64,6 +64,9 @@ class CommandRegistry implements ServiceInterface
     public function autoloadNamespaces(string $commandSource): void
     {
         foreach (glob($commandSource . '/*', GLOB_ONLYDIR) as $namespacePath) {
+            if (file_exists($namespacePath . '/composer.json')) {
+                //this looks like a 3rd party package, so lets run a sec check
+            }
             $this->registerNamespace(basename($namespacePath), $commandSource);
         }
     }

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -40,6 +40,19 @@ it('asserts App has CommandRegistry Service', function () {
     $this->assertTrue($registry instanceof CommandRegistry);
 });
 
+it('asserts App parses command path with @vendor tag', function () {
+    $app = new \Minicli\App([
+        'app_path' => '@namespace/command'
+    ]);
+
+    $registry = $app->commandRegistry;
+    $paths = $registry->getCommandsPath();
+    $this->assertIsArray($paths);
+    $this->assertCount(1, $paths);
+    var_dump($paths);
+    $this->assertStringEndsWith("namespace/command/Command", $paths[0]);
+});
+
 it('asserts App has Printer service', function () {
     $app = getBasicApp();
 


### PR DESCRIPTION
This PR makes it easier to reference 3rd party commands from the vendor folder. Instead or providing a full path to the command path, such as: `__DIR__ . '/vendor/namespace/command/Command'`, you can now simply use `@namespace/command` and the application will automatically expand that to the full path in the vendor folder.

I will be working to update the docs soon. As a TL;DR, now you can share and reuse Minicli commands . The procedure is:

1. Create your command following the [minicli/command-demo](https://github.com/minicli/command-demo) structure.
2. Configure the `composer.json` for the command accordingly and submit it to [Packagist](https://packagist.org).
3. Require the command from your base Minicli app.
4. Include a reference to the command in your app config. For instance:

```php
$app = new App([
    'app_path' => [
            __DIR__ . '/app/Command',
            '@minicli/command-demo'
        ],
    'debug' => true
]);
```

And that should be all. More to come soon! :)