### PR TITLE
Optimize code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,11 @@
   "keywords": ["cli","command-line"],
   "autoload": {
     "psr-4": {
-      "Minicli\\": "src/",
+      "Minicli\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "Assets\\": "tests/Assets"
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "php": ">=8"
+    "php": ">=8",
+    "ext-readline": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",
@@ -28,8 +29,5 @@
   "scripts": {
     "test" : ["pest"],
     "csfix": ["php-cs-fixer fix"]
-  },
-  "suggest": {
-    "ext-readline": "For obtaining user input"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b83761c262dfc9fb027419bd3ce3de9",
+    "content-hash": "e01e6be30514942bf44b7cf637c47640",
     "packages": [],
     "packages-dev": [
         {
@@ -4439,7 +4439,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8"
+        "php": ">=8",
+        "ext-readline": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,6 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>

--- a/src/Command/CommandCall.php
+++ b/src/Command/CommandCall.php
@@ -80,7 +80,7 @@ class CommandCall
                 continue;
             }
 
-            if (substr($arg, 0, 2) == '--') {
+            if (str_starts_with($arg, '--')) {
                 $this->flags[] = $arg;
                 continue;
             }

--- a/src/Command/CommandController.php
+++ b/src/Command/CommandController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Minicli\Command;
 
-use JetBrains\PhpStorm\Pure;
 use Minicli\App;
 use Minicli\ControllerInterface;
 use Minicli\Output\OutputHandler;

--- a/src/Command/CommandNamespace.php
+++ b/src/Command/CommandNamespace.php
@@ -45,6 +45,7 @@ class CommandNamespace
     /**
      * Load namespace controllers
      *
+     * @param string $commandsPath
      * @return array
      */
     public function loadControllers(string $commandsPath): array

--- a/src/Command/CommandRegistry.php
+++ b/src/Command/CommandRegistry.php
@@ -140,11 +140,7 @@ class CommandRegistry implements ServiceInterface
     {
         $namespace = $this->getNamespace($command);
 
-        if ($namespace !== null) {
-            return $namespace->getController($subcommand);
-        }
-
-        return null;
+        return $namespace?->getController($subcommand);
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -31,7 +31,7 @@ class Config implements ServiceInterface
      */
     public function __get(string $name): mixed
     {
-        return isset($this->config[$name]) ? $this->config[$name] : null;
+        return $this->config[$name] ?? null;
     }
 
     /**

--- a/src/Input.php
+++ b/src/Input.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Minicli;
 
-use RuntimeException;
-
 class Input
 {
     /**
@@ -29,7 +27,6 @@ class Input
      */
     public function __construct($prompt = 'minicli$> ')
     {
-        $this->checkReadlineExtension();
         $this->setPrompt($prompt);
     }
 
@@ -40,7 +37,6 @@ class Input
      */
     public function read(): string
     {
-        $this->checkReadlineExtension();
         $input = readline($this->getPrompt());
         $this->inputHistory[] = $input;
 
@@ -76,20 +72,5 @@ class Input
     public function setPrompt(string $prompt): void
     {
         $this->prompt = $prompt;
-    }
-
-    /**
-     * check read line extension
-     *
-     * @return void
-     * @throws RuntimeException
-     */
-    private function checkReadlineExtension(): void
-    {
-        if (extension_loaded('readline')) {
-            return;
-        }
-
-        throw new RuntimeException('Extension readline is required.');
     }
 }

--- a/src/Output/Helper/TableHelper.php
+++ b/src/Output/Helper/TableHelper.php
@@ -100,14 +100,14 @@ class TableHelper
     /**
      * Returns the formatted table for printing
      *
-     * @param OutputFilterInterface $filter In case no filter is provided, a SimpleOutputFilter is used by default.
+     * @param OutputFilterInterface|null $filter In case no filter is provided, a SimpleOutputFilter is used by default.
      * @return string
      */
     public function getFormattedTable(OutputFilterInterface $filter = null): string
     {
         $filter = $filter ?? new SimpleOutputFilter();
 
-        foreach ($this->styledRows as $index => $item) {
+        foreach ($this->styledRows as $item) {
             $style = $item['style'];
             $row = $this->getRowAsString($item['row']);
 
@@ -140,7 +140,7 @@ class TableHelper
     {
         $columnSizes = [];
 
-        foreach ($this->tableRows as $rowNumber => $rowContent) {
+        foreach ($this->tableRows as $rowContent) {
             $columnCount = 0;
 
             foreach ($rowContent as $cell) {
@@ -159,10 +159,9 @@ class TableHelper
      * Transforms a row into a formatted string, with adequate column sizing
      *
      * @param array $row
-     * @param int $colSize
      * @return string
      */
-    protected function getRowAsString(array $row, int $colSize = 5): string
+    protected function getRowAsString(array $row): string
     {
         //first, determine the size of each column
         $columnSizes  = $this->calculateColumnSizes();

--- a/src/Output/Theme/DefaultTheme.php
+++ b/src/Output/Theme/DefaultTheme.php
@@ -31,12 +31,12 @@ class DefaultTheme implements CLIThemeInterface
     /**
      * Obtains the colors that compose a style for that theme, such as "error" or "success"
      *
-     * @param string $style_name
+     * @param string $name
      * @return array An array containing FG color and optionally BG color
      */
-    public function getStyle(string $style_name): array
+    public function getStyle(string $name): array
     {
-        return $this->styles[$style_name] ?? $this->styles['default'];
+        return $this->styles[$name] ?? $this->styles['default'];
     }
 
     /**


### PR DESCRIPTION
Hi there, thanks for your great work 🌟

Changes:
- Moved `readline-ext` from `suggest` to `require`, because that's a required ext. 😄
- Preferred php 8 functions, for example replaces `substr` with `str_starts_with` when needed.
- Moved `Assests` to `autoload-dev`, because I will not like to have `Assests` namespace in my production environment.
- Removed redundant variables & arguments.

I am open to receive your comments ✌️