### PR TITLE
Decrease package size with `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+* text=auto
+
+*.blade.php diff=html
+*.css diff=css
+*.html diff=html
+*.md diff=markdown
+*.php diff=php
+
+/.github export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.php export-ignore
+CODE_OF_CONDUCT.md export-ignore
+CONTRIBUTING.md export-ignore
+CONTRIBUTORS.md export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file to decrease the package size by ignoring specific files and folders that aren't directly package related and don't need to be downloaded when minicli is required.

By adding the `.gitattributes` the download size went from roughly 245 KB to 209 KB, a decrease in size of ~14%.

While we are only talking kilobytes here it does add up in the end, both in hard drive space and bandwidth. So adding a `.gitattributes` file helps in both saving hard drive space and bandwidth for the end user.