### PR TITLE
Fixing param null if its value has "="

### DIFF
--- a/src/Command/CommandCall.php
+++ b/src/Command/CommandCall.php
@@ -73,10 +73,10 @@ class CommandCall
     protected function parseCommand(array $argv): void
     {
         foreach ($argv as $arg) {
-            $pair = explode('=', $arg);
+            $parts = explode('=', $arg);
 
-            if (count($pair) == 2) {
-                $this->params[$pair[0]] = $pair[1];
+            if (count($parts) >= 2) {
+                $this->params[$parts[0]] = join('=', array_slice($parts, 1));
                 continue;
             }
 

--- a/tests/Feature/Command/CommandCallTest.php
+++ b/tests/Feature/Command/CommandCallTest.php
@@ -29,3 +29,10 @@ it('asserts params are correctly set', function () {
     $this->assertTrue($call->hasParam('name'));
     $this->assertEquals('test', $call->getParam('name'));
 });
+
+it('asserts params are correctly set if value contains "="', function () {
+    $call = new CommandCall(["minicli", "help", "test", "name=first=john&last=doe"]);
+
+    $this->assertTrue($call->hasParam('name'));
+    $this->assertEquals('first=john&last=doe', $call->getParam('name'));
+});


### PR DESCRIPTION
Fix the value of param when it contains the char "="

```
./minicli mycommand myparam="var1=10&var2=20"
```

before `$commandCall->getParam('myparam')` was returning `NULL`, now it return `"var1=10&var2=20"`


