### PR TITLE
Allow using Closures as a Service

### DIFF
--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -69,6 +69,24 @@ it('asserts App returns null when a service is not found', function () {
     $this->assertNull($service);
 });
 
+it ('asserts App can handle a closure as a service', function () {
+    $app = getBasicApp();
+    $app->addService('closure', function () {
+        return 'closure';
+    });
+
+    $this->assertEquals('closure', $app->closure);
+});
+
+it('asserts Closure service gets passed the App instance', function () {
+    $app = getBasicApp();
+    $app->addService('closure', function ($app) {
+        return $app;
+    });
+
+    $this->assertEquals($app, $app->closure);
+});
+
 it('asserts App registers and executes single command', function () {
     $app = getBasicApp();
 


### PR DESCRIPTION
Now its possible to register Closures as a Service #35 , The current `App` instance will be passed to this closure.