### PR TITLE
Allow themes to override ColorOutputFilter

### DIFF
--- a/src/Output/CLIThemeInterface.php
+++ b/src/Output/CLIThemeInterface.php
@@ -2,6 +2,8 @@
 
 namespace Minicli\Output;
 
+use Minicli\Output\OutputFilterInterface;
+
 interface CLIThemeInterface
 {
     /**
@@ -10,4 +12,10 @@ interface CLIThemeInterface
      * @return array An array containing FG color and optionally BG color
      */
     public function getStyle(string $name);
+
+    /**
+     * Initialize and return an OutputFilter for our theme class.
+     * @return OutputFilterInterface
+     */
+    public function getOutputFilter();
 }

--- a/src/Output/Filter/ColorOutputFilter.php
+++ b/src/Output/Filter/ColorOutputFilter.php
@@ -65,6 +65,10 @@ class ColorOutputFilter implements OutputFilterInterface
             $bg = ';' . $style_colors[1];
         }
 
-        return sprintf("\e[%s%sm%s\e[0m", $style_colors[0], $bg, $message);
+        $fg = $style_colors[0] ?? null;
+        
+        return $fg ?
+            sprintf("\e[%s%sm%s\e[0m", $fg, $bg, $message) :
+            $message;
     }
 }

--- a/src/Output/Helper/ThemeHelper.php
+++ b/src/Output/Helper/ThemeHelper.php
@@ -21,12 +21,12 @@ class ThemeHelper
 
     /**
      * Initialize and return an OutputFilter based on our theme class.
-     * @return ColorOutPutFilter
+     * @return OutputFilterInterface
      */
     public function getOutputFilter()
     {
         if (class_exists($this->theme)) {
-            return new ColorOutputFilter(new $this->theme());
+            return (new $this->theme())->getOutputFilter();
         }
 
         return new ColorOutputFilter();

--- a/src/Output/Theme/DefaultTheme.php
+++ b/src/Output/Theme/DefaultTheme.php
@@ -4,6 +4,7 @@ namespace Minicli\Output\Theme;
 
 use Minicli\Output\CLIColors;
 use Minicli\Output\CLIThemeInterface;
+use Minicli\Output\Filter\ColorOutputFilter;
 
 class DefaultTheme implements CLIThemeInterface
 {
@@ -40,6 +41,14 @@ class DefaultTheme implements CLIThemeInterface
     public function setStyle(string $name, array $style): void
     {
         $this->styles[$name] = $style;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOutputFilter()
+    {
+        return new ColorOutputFilter($this);
     }
 
     /**

--- a/src/Output/Theme/RawTheme.php
+++ b/src/Output/Theme/RawTheme.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Minicli\Output\Theme;
+
+use Minicli\Output\CLIThemeInterface;
+use Minicli\Output\Filter\SimpleOutputFilter;
+
+class RawTheme implements CLIThemeInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function getStyle(string $style_name): array
+    {
+        return [null];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOutputFilter()
+    {
+        return new SimpleOutputFilter;
+    }
+}


### PR DESCRIPTION
I would like to be able to disable all colours when redirecting output to a log file, for example:

Eg:
$app = new App([
    'theme' => stream_isatty(STDOUT) ? 'App\Theme\Default' : '\Raw',
]);