### PR TITLE
Creating a new AppFactory for alternative creation approach

### DIFF
--- a/src/Factories/AppFactory.php
+++ b/src/Factories/AppFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minicli\Factories;
+
+use Minicli\App;
+
+final class AppFactory
+{
+    /**
+     * Create a new Instance of an App.
+     * @param array $config
+     * @param string $signature
+     * @return App
+     */
+    public static function make(
+        array $config = [],
+        string $signature = '/minicli help',
+    ): App {
+        return new App(
+            config: $config,
+            signature: $signature,
+        );
+    }
+}

--- a/tests/Feature/Factories/AppFactoryTest.php
+++ b/tests/Feature/Factories/AppFactoryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Minicli\App;
+use Minicli\Factories\AppFactory;
+
+test('it can create a new app')
+    ->expect(fn () => AppFactory::make(
+        config: [
+            'app_path' => __DIR__ . '/../app/Command',
+            'theme' => '',
+            'debug' => true,
+        ],
+        signature: '/minicli help',
+    ))->toBeInstanceOf(App::class);


### PR DESCRIPTION
This PR adds a new class `AppFactory` which will allow an alternative syntax for creating a Minicli application.

Currently, to create an app you need to:

```php
$app = new App(
    config: [
        'app_path' => [
        __DIR__ . '/app/Command',
    ],
    'theme' => '\Unicorn', 
    'debug' => false,
    ],
);
```

You will now be able to use this approach and get the same result:

```php
$app = AppFactory::make(
    config: [
        'app_path' => [
        __DIR__ . '/app/Command',
    ],
    'theme' => '\Unicorn', 
    'debug' => false,
    ],
);
```


This approach is more of a Developer Experience improvement than an actual improvement to the library.
