### PR TITLE
Adding the ability to ask a question on the printer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.5",
-    "pestphp/pest": "^2.5"
+    "pestphp/pest": "^2.5",
+    "mockery/mockery": "^1.5"
   },
   "scripts": {
     "test" : ["pest"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33aa18ae20dc1579e68631874ac51ab9",
+    "content-hash": "17e200d7861df4cf4ab7b664c213f7fd",
     "packages": [],
     "packages-dev": [
         {
@@ -745,6 +745,57 @@
             "time": "2023-04-02T19:30:06+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.0.5",
             "source": {
@@ -802,6 +853,78 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.5"
             },
             "time": "2021-10-08T21:21:46+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
+                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/mockery/mockery/issues",
+                "source": "https://github.com/mockery/mockery/tree/1.5.1"
+            },
+            "time": "2022-09-07T15:32:08+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/Output/OutputHandler.php
+++ b/src/Output/OutputHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Minicli\Output;
 
+use InvalidArgumentException;
 use Minicli\App;
+use Minicli\Input;
 use Minicli\Output\Adapter\DefaultPrinterAdapter;
 use Minicli\Output\Helper\TableHelper;
 use Minicli\ServiceInterface;
@@ -175,5 +177,27 @@ class OutputHandler implements ServiceInterface
         $this->newline();
         $this->rawOutput($helper->getFormattedTable($filter));
         $this->newline();
+    }
+
+    /**
+     * Ask the users input
+     *
+     * @param string $content
+     * @param bool $alt
+     * @return string
+     */
+    public function ask(string $content, string $method = 'display'): string
+    {
+        if (! method_exists($this, $method)) {
+            throw new InvalidArgumentException(
+                message: "No output for [$method]",
+            );
+        }
+
+        $this->{$method}(
+            $content,
+        );
+
+        return (new Input())->read();
     }
 }

--- a/tests/Feature/Output/OutputHandlerTest.php
+++ b/tests/Feature/Output/OutputHandlerTest.php
@@ -53,7 +53,7 @@ it('asserts that OutputHandler prints table', function () {
     $printer->printTable($table);
 })->expectOutputRegex('/(\s*ID\s*)/');
 
-it('asserts a question can be asked', function () {
+it('asserts a question can be asked', function (): void {
     $printer = Mockery::mock(OutputHandler::class);
     $printer->shouldReceive('ask');
 
@@ -61,3 +61,12 @@ it('asserts a question can be asked', function () {
         $printer->ask('Test'),
     )->toBeString();
 });
+
+it('throws an exception if asking a question and display method does not exist', function (): void {
+    $printer = getSimpleOutputHandler();
+
+    $printer->ask(
+        content: 'test',
+        method: 'awesome',
+    );
+})->throws(InvalidArgumentException::class);

--- a/tests/Feature/Output/OutputHandlerTest.php
+++ b/tests/Feature/Output/OutputHandlerTest.php
@@ -52,3 +52,12 @@ it('asserts that OutputHandler prints table', function () {
     $printer = getSimpleOutputHandler();
     $printer->printTable($table);
 })->expectOutputRegex('/(\s*ID\s*)/');
+
+it('asserts a question can be asked', function () {
+    $printer = Mockery::mock(OutputHandler::class);
+    $printer->shouldReceive('ask');
+
+    expect(
+        $printer->ask('Test'),
+    )->toBeString();
+});


### PR DESCRIPTION
This PR adds the ability to `ask` for user input on the printer, this is a Developer Experience improvement that makes this logic easier to perform.

Previously we would have to:

```php
$app->registerCommand('mycommand', function(CommandCall $input) use ($app) {
      $question = $this->display('Here is a question');

    $response = (new Input())->read();

   // Do something with the input.
});
```

Now we can do this a little simpler:

```php
$app->registerCommand('mycommand', function(CommandCall $input) use ($app) {
    $response = $this->ask('Here is a question');
   
    // Do something with the input.
});
```
