### PR TITLE
Update README file to list all built-in themes and link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ The [documentation](https://docs.minicli.dev) contains more detailed information
 
 ## Color Themes
 
-Minicli supports the use of color themes to change the style of command line output. There is currently 1 built-in theme other than the default theme:
+Minicli supports the use of color themes to change the style of command line output. There is currently 3 built-in themes other than the default theme:
 
-- Unicorn
+- **[Unicorn](https://docs.minicli.dev/en/latest/output/using-themes/#unicorn)**: a more colorful theme.
+- **[Dalton](https://docs.minicli.dev/en/latest/output/using-themes/#dalton)**: a color-blind friendly theme.
+- **[Dracula](https://docs.minicli.dev/en/latest/output/using-themes/#dracula)**: a popular dark theme.
 
 To set the theme, pass in a configuration array with a `theme` value when initializing App in the script. Built-in themes need a leading `\` character:
 


### PR DESCRIPTION
This is a PR to complete the work on this one I created in the docs repository:
https://github.com/minicli/docs/pull/49

This is adding the list of all built-in themes with a link to the docs website.