### PR TITLE
[feat] Add fallback to shell's "read" command.

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -68,7 +68,7 @@ class Input
      * @return string
      * @throws \Exception
      */
-    public function detectAndReturnPrompt(): string
+    private function detectAndReturnPrompt(): string
     {
         return match (true) {
             null !== shell_exec("command -v read")  => $this->useShellPrompt(),

--- a/src/Input.php
+++ b/src/Input.php
@@ -94,7 +94,7 @@ class Input
      */
     private function useShellPrompt(): string
     {
-        $command='read -rp ' . escapeshellarg($this->getPrompt()) . ' input; echo $input';
+        $command = 'read -rp ' . escapeshellarg($this->getPrompt()) . ' input; echo $input';
         
         return shell_exec($command);
     }

--- a/src/Input.php
+++ b/src/Input.php
@@ -23,7 +23,7 @@ class Input
      */
     public function read(): string
     {
-        $input = (string) readline($this->getPrompt());
+        $input = (string) $this->detectAndReturnPrompt();
 
         $this->inputHistory[] = $input;
 
@@ -59,5 +59,41 @@ class Input
     public function setPrompt(string $prompt): void
     {
         $this->prompt = $prompt;
+    }
+    
+
+    /**
+     * Blah
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public function detectAndReturnPrompt(): string
+    {
+        return match (true) {
+            null !== shell_exec("command -v read")  => $this->useShellPrompt(),
+            extension_loaded("readline") => $this->useReadlinePrompt(),
+            default => throw new \Exception('Unexpected match value'),
+        };
+    }
+
+    /**
+     * Blah
+     *
+     * @return string
+     */
+    private function useReadlinePrompt(): string
+    {
+        return readline($this->getPrompt());
+    }
+
+    /**
+     * Blah
+     *
+     * @return string
+     */
+    private function useShellPrompt(): string
+    {
+        return shell_exec('read -rp ' . escapeshellarg($this->getPrompt()) . ' input; echo $input');
     }
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -71,8 +71,8 @@ class Input
     private function detectAndReturnPrompt(): string
     {
         return match (true) {
-            null !== shell_exec("command -v read")  => $this->useShellPrompt(),
             extension_loaded("readline") => $this->useReadlinePrompt(),
+            null !== shell_exec("command -v read")  => $this->useShellPrompt(),
             default => throw new \Exception('Unexpected match value'),
         };
     }

--- a/src/Input.php
+++ b/src/Input.php
@@ -94,6 +94,8 @@ class Input
      */
     private function useShellPrompt(): string
     {
-        return shell_exec('read -rp ' . escapeshellarg($this->getPrompt()) . ' input; echo $input');
+        $command='read -rp ' . escapeshellarg($this->getPrompt()) . ' input; echo $input';
+        
+        return shell_exec($command);
     }
 }


### PR DESCRIPTION
I have just been playing with minicli and I like it. The readme says:

> Note: If you want to obtain user input, then the [readline](https://www.php.net/manual/en/function.readline.php) PHP extension is required as well.

I wondered why this is necessary here. We are in a CLI. So why not leverage the CLI for this functionality instead of fiddling with PHP extensions?

## Added

This PR adds functionality to check if the PHP `readline` extension is available. If not, we fall back on the shell command `read`, or (tbd) throw and exception if none of the options are available.

## Todo / Thoughts

This is just a draft to visualise my idea and see if you are interested. If this is something you want to merge, the following things need to be done or considered:

1. A `match()` was used, but I am open to handling this differently. I chose to use the match because it is easy to add more cases. For example, if you are interested in merging this, I would add OS related checks.
2. Preferably I would throw an exception if none of the match cases has a match. Probably good to wrap this in a try/catch. Open to ideas/feedback.
3. Both `readline` and `read` could return false (or `null`). As this is not covered in the existing code, I have not touched it yet. Opinions?
4. Doc blocks aren't ready yet.
5. Not sure about tests. We are dealing with Infra here.

