### PR TITLE
Add required parameters check for commands

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -10,6 +10,7 @@ use Minicli\Command\CommandCall;
 use Minicli\Command\CommandRegistry;
 use Minicli\DI\Container;
 use Minicli\Exception\CommandNotFoundException;
+use Minicli\Exception\MissingParametersException;
 use Minicli\Output\Helper\ThemeHelper;
 use Minicli\Output\OutputHandler;
 use Throwable;
@@ -278,10 +279,17 @@ class App
         $controller = $this->commandRegistry->getCallableController((string) $input->command, $input->subcommand);
 
         if ($controller instanceof ControllerInterface) {
-            $controller->boot($this);
-            $controller->run($input);
-            $controller->teardown();
-            return;
+            try {
+                $controller->boot($this, $input);
+                $controller->run($input);
+                $controller->teardown();
+
+                return;
+            } catch (MissingParametersException $exception) {
+                $this->error($exception->getMessage());
+
+                return;
+            }
         }
 
         $this->runSingle($input);

--- a/src/Command/CommandController.php
+++ b/src/Command/CommandController.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Minicli\App;
 use Minicli\Config;
 use Minicli\ControllerInterface;
+use Minicli\Exception\MissingParametersException;
 use Minicli\Output\OutputHandler;
 
 /**
@@ -54,13 +55,21 @@ abstract class CommandController implements ControllerInterface
      * Called before `run`
      *
      * @param App $app
+     * @param CommandCall $input
      * @return void
+     * @throws MissingParametersException
      */
-    public function boot(App $app): void
+    public function boot(App $app, CommandCall $input): void
     {
         $this->app = $app;
         $this->config = $app->config;
         $this->printer = $app->getPrinter();
+
+        $missing = array_diff($this->required(), array_keys($input->params));
+
+        if ([] !== $missing) {
+            throw new MissingParametersException($missing);
+        }
     }
 
     /**
@@ -72,6 +81,16 @@ abstract class CommandController implements ControllerInterface
     {
         $this->input = $input;
         $this->handle();
+    }
+
+    /**
+     * The list of parameters required by the command.
+     *
+     * @return array<int, string>
+     */
+    public function required(): array
+    {
+        return [];
     }
 
     /**

--- a/src/ControllerInterface.php
+++ b/src/ControllerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Minicli;
 
 use Minicli\Command\CommandCall;
+use Minicli\Exception\MissingParametersException;
 
 interface ControllerInterface
 {
@@ -12,9 +13,11 @@ interface ControllerInterface
      * Called before `run`
      *
      * @param App $app
+     * @param CommandCall $input
      * @return void
+     * @throws MissingParametersException
      */
-    public function boot(App $app): void;
+    public function boot(App $app, CommandCall $input): void;
 
     /**
      * Main execution
@@ -23,6 +26,13 @@ interface ControllerInterface
      * @return void
      */
     public function run(CommandCall $input): void;
+
+    /**
+     * The list of parameters required by the command.
+     *
+     * @return array<int,string>
+     */
+    public function required(): array;
 
     /**
      * Called when `run` is successfully finished

--- a/src/Exception/CommandNotFoundException.php
+++ b/src/Exception/CommandNotFoundException.php
@@ -6,6 +6,6 @@ namespace Minicli\Exception;
 
 use Exception;
 
-class CommandNotFoundException extends Exception
+final class CommandNotFoundException extends Exception
 {
 }

--- a/src/Exception/MissingParametersException.php
+++ b/src/Exception/MissingParametersException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minicli\Exception;
+
+use Exception;
+
+final class MissingParametersException extends Exception
+{
+    /**
+     * @param array<int,string> $missing
+     */
+    public function __construct(array $missing)
+    {
+        parent::__construct(sprintf(
+            'Missing required parameter(s): %s',
+            implode(', ', $missing)
+        ));
+    }
+}

--- a/tests/Assets/Command/Test/RequiredController.php
+++ b/tests/Assets/Command/Test/RequiredController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\Command\Test;
+
+use Minicli\Command\CommandController;
+
+class RequiredController extends CommandController
+{
+    public function handle(): void
+    {
+        $this->rawOutput("Hello, {$this->getParam('name')}");
+    }
+
+    public function required(): array
+    {
+        return ['name'];
+    }
+}

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -71,7 +71,7 @@ it('asserts App registers and executes single command', function (): void {
     $app = getBasicApp();
 
     $app->registerCommand('minicli-test', function () use ($app): void {
-        $app->getPrinter()->rawOutput("testing minicli");
+        $app->rawOutput("testing minicli");
     });
 
     $command = $app->commandRegistry->getCallable('minicli-test');
@@ -105,10 +105,23 @@ it('asserts App throws exception when command is not callable', function (): voi
 })->expectException(\TypeError::class);
 
 $app = new App();
-$errorNotFound = $app->getPrinter()->filterOutput("Command \"inexistent-command\" not found.", 'error');
+$errorNotFound = $app->filterOutput("Command \"inexistent-command\" not found.", 'error');
+$errorMissingParams = $app->filterOutput("Missing required parameter(s): name", 'error');
 
 it('asserts App shows error when debug is set to false and command is not found', function (): void {
     $app = getProdApp();
 
     $app->runCommand(['minicli', 'inexistent-command']);
-})->expectOutputString("\n".$errorNotFound."\n");
+})->expectOutputString("\n{$errorNotFound}\n");
+
+it('asserts App runs command successfully when required parameters are provided', function (): void {
+    $app = getProdApp();
+
+    $app->runCommand(['minicli', 'test', 'required', 'name=erika']);
+})->expectOutputString('Hello, erika');
+
+it('asserts App shows error when required parameters are not provided', function (): void {
+    $app = getProdApp();
+
+    $app->runCommand(['minicli', 'test', 'required']);
+})->expectOutputString("\n{$errorMissingParams}\n");

--- a/tests/Feature/Command/CommandRegistryTest.php
+++ b/tests/Feature/Command/CommandRegistryTest.php
@@ -50,7 +50,7 @@ it('assets Registry returns full command list', function (): void {
 
     expect($commandList)->toBeArray()
         ->toHaveCount(2)
-        ->and($commandList['test'])->toBeArray()->toHaveCount(4);
+        ->and($commandList['test'])->toBeArray()->toHaveCount(5);
 });
 
 it('assets Registry returns full command list when with multiple command sources', function (): void {
@@ -59,6 +59,6 @@ it('assets Registry returns full command list when with multiple command sources
 
     expect($commandList)->toBeArray()
         ->toHaveCount(2)
-        ->and($commandList['test'])->toBeArray()->toHaveCount(4)
+        ->and($commandList['test'])->toBeArray()->toHaveCount(5)
         ->and($commandList['vendor'])->toBeArray()->toHaveCount(1);
 });


### PR DESCRIPTION
This PR adds the feature to configure required parameters for the commands extending the `CommandController`.

By default an empty array will be returned from the CommandController for backwards compatibility:

```php
/**
 * The list of parameters required by the command.
 *
 * @return array<int, string>
 */
public function required(): array
{
    return [];
}
```

To define the required parameters for a command, developers should only implement the `required` method to return the list of parameters that should be required.

When running a command without any of the required parameters, an error message will be shown listing the required parameters that are missing.