### PR TITLE
register multiple commands

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -170,7 +170,16 @@ class App
     {
         $this->commandRegistry->registerCommand($name, $callable);
     }
-
+    /**
+     * @param array<string, callable> $commands
+     * @return void
+     */
+    public function registerCommands(array $commands): void
+    {
+        foreach ($commands as $name => $callable) {
+            $this->registerCommand($name, $callable);
+        }
+    }
     /**
      * @param array<int,string> $argv
      * @return void

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -94,19 +94,19 @@ it('asserts App executes command from namespace', function (): void {
 
     $app->runCommand(['minicli', 'test']);
 })->expectOutputString("test default");
-it('registers multiple commands', function ():void {
+it('registers multiple commands', function (): void {
     // Create a new instance of the App
     $app = getBasicApp();
 
     // Define the commands to register
     $commands = [
-        'command1' => function ($input) use($app) {
-            $app->success('Hello World!' , false);
-            $app->info('With Background!' , true);
+        'command1' => function ($input) use ($app): void {
+            $app->success('Hello World!', false);
+            $app->info('With Background!', true);
         },
-        'command2' => function ($input) use($app)  {
-            $app->success('Hello World!' , false);
-            $app->info('With Background!' , true);
+        'command2' => function ($input) use ($app): void {
+            $app->success('Hello World!', false);
+            $app->info('With Background!', true);
         },
         // Add more commands here
     ];

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -94,7 +94,32 @@ it('asserts App executes command from namespace', function (): void {
 
     $app->runCommand(['minicli', 'test']);
 })->expectOutputString("test default");
+it('registers multiple commands', function ():void {
+    // Create a new instance of the App
+    $app = getBasicApp();
 
+    // Define the commands to register
+    $commands = [
+        'command1' => function ($input) use($app) {
+            $app->success('Hello World!' , false);
+            $app->info('With Background!' , true);
+        },
+        'command2' => function ($input) use($app)  {
+            $app->success('Hello World!' , false);
+            $app->info('With Background!' , true);
+        },
+        // Add more commands here
+    ];
+
+    // Call the registerCommands method
+    $app->registerCommands($commands);
+    $commandRegistry = $app->commandRegistry;
+
+    // Assert that each command is registered correctly
+    foreach ($commands as $command => $callable) {
+        expect($commandRegistry->getCallable($command))->toBe($callable);
+    }
+});
 it('asserts App prints signature when no command is specified', function (): void {
     $app = getBasicApp();
     $app->setOutputHandler(new OutputHandler(new DefaultPrinterAdapter()));


### PR DESCRIPTION
This is a method named `registerCommands` that allows to register many commands instead of one command.
```
 /**
     * @param array<string, callable> $commands
     * @return void
     */
    public function registerCommands(array $commands): void
    {
        foreach ($commands as $name => $callable) {
            $this->registerCommand($name, $callable);
        }
    }
```