### PR TITLE
Add support to register services using a config file

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -56,6 +56,7 @@ class App
     public function boot(array $config, string $signature): void
     {
         $this->loadConfig($config, $signature);
+        $this->loadServices();
 
         $commandsPath = $this->config->app_path;
         if ( ! is_array($commandsPath)) {
@@ -261,5 +262,17 @@ class App
             : $signature;
 
         $this->setSignature($appSignature);
+    }
+
+    protected function loadServices(): void
+    {
+        $services = $this->config->services ?? [];
+        if ([] === $services) {
+            return;
+        }
+
+        foreach ($services as $name => $service) {
+            $this->addService($name, new $service());
+        }
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -8,6 +8,7 @@ namespace Minicli;
  * @property string $app_name
  * @property string|array $app_path
  * @property string $theme
+ * @property array<string, class-string<ServiceInterface>> $services
  * @property boolean $debug
  */
 class Config implements ServiceInterface

--- a/tests/Assets/Services/TestService.php
+++ b/tests/Assets/Services/TestService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Assets\Services;
+
+use Minicli\App;
+use Minicli\ServiceInterface;
+
+class TestService implements ServiceInterface
+{
+    public function load(App $app): void
+    {
+    }
+
+    public function hello(): string
+    {
+        return 'Hello World!';
+    }
+}

--- a/tests/Assets/config/services.php
+++ b/tests/Assets/config/services.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Assets\Services\TestService;
+
+return [
+    /****************************************************************************
+     * Application Services
+     * --------------------------------------------------------------------------
+     *
+     * The services to be loaded for your application.
+     *****************************************************************************/
+
+    'services' => [
+        'test' => TestService::class,
+    ],
+];

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -76,6 +76,11 @@ it('asserts Closure service gets passed the App instance', function (): void {
     expect($app->closure)->toBe($app);
 });
 
+it('asserts App can load service from config file', function (): void {
+    $app = getConfiguredApp();
+    expect($app->test->hello())->toBe('Hello World!');
+});
+
 it('asserts App registers and executes single command', function (): void {
     $app = getBasicApp();
 


### PR DESCRIPTION
## Changes

This PR is adding the support to automatically register services using a config/services.php config file that will be added to the official templates in follow-up PRs.

## Why

The goal is to improve the DX to avoid the need of the developers to edit the executable file just to add services.