### PR TITLE
Add Logger Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 vendor/
+logs/
 .php_cs.cache
 .phpunit.result.cache
 .composer

--- a/src/App.php
+++ b/src/App.php
@@ -11,6 +11,7 @@ use Minicli\Command\CommandRegistry;
 use Minicli\DI\Container;
 use Minicli\Exception\CommandNotFoundException;
 use Minicli\Exception\MissingParametersException;
+use Minicli\Logging\Logger;
 use Minicli\Output\Helper\ThemeHelper;
 use Minicli\Output\OutputHandler;
 use ReflectionException;
@@ -18,11 +19,13 @@ use Throwable;
 
 /**
  * @property Config $config
+ * @property Logger $logger
  * @property OutputHandler $printer
  * @property CommandRegistry $commandRegistry
  * @property string $appSignature
  * @property string $base_path
  * @property string $config_path
+ * @property string $logs_path
  * @mixin OutputHandler
  */
 class App
@@ -248,6 +251,7 @@ class App
 
         $this->container->bind('base_path', fn () => $appRoot);
         $this->container->bind('config_path', fn () => "{$appRoot}/config");
+        $this->container->bind('logs_path', fn () => "{$appRoot}/logs");
     }
 
     /**
@@ -275,6 +279,8 @@ class App
 
     protected function loadServices(): void
     {
+        $this->loadDefaultServices();
+
         $services = $this->config->services ?? [];
         if ([] === $services) {
             return;
@@ -283,5 +289,10 @@ class App
         foreach ($services as $name => $service) {
             $this->addService($name, new $service());
         }
+    }
+
+    protected function loadDefaultServices(): void
+    {
+        $this->addService('logger', new Logger());
     }
 }

--- a/src/App.php
+++ b/src/App.php
@@ -208,6 +208,7 @@ class App
 
                 return;
             } catch (MissingParametersException $exception) {
+                $this->logger->error($exception->getMessage());
                 $this->error($exception->getMessage());
 
                 return;
@@ -226,7 +227,9 @@ class App
             $callable = $this->commandRegistry->getCallable((string) $input->command);
         } catch (Throwable $exception) {
             if ( ! $this->config->debug) {
+                $this->logger->error($exception->getMessage());
                 $this->error($exception->getMessage());
+
                 return false;
             }
             throw $exception;

--- a/src/Command/CommandController.php
+++ b/src/Command/CommandController.php
@@ -9,6 +9,7 @@ use Minicli\App;
 use Minicli\Config;
 use Minicli\ControllerInterface;
 use Minicli\Exception\MissingParametersException;
+use Minicli\Logging\Logger;
 use Minicli\Output\OutputHandler;
 
 /**
@@ -29,6 +30,13 @@ abstract class CommandController implements ControllerInterface
      * @param Config $config
      */
     protected Config $config;
+
+    /**
+     * logger instance.
+     *
+     * @param Logger $logger
+     */
+    protected Logger $logger;
 
     /**
      * command call instance.
@@ -63,6 +71,7 @@ abstract class CommandController implements ControllerInterface
     {
         $this->app = $app;
         $this->config = $app->config;
+        $this->logger = $app->logger;
         $this->printer = $app->getPrinter();
 
         $missing = array_diff($this->required(), array_keys($input->params));

--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,7 @@ namespace Minicli;
  * @property string|array $app_path
  * @property string $theme
  * @property array<string, class-string<ServiceInterface>> $services
+ * @property array<string, string> $logging
  * @property boolean $debug
  */
 class Config implements ServiceInterface

--- a/src/Logging/LogLevel.php
+++ b/src/Logging/LogLevel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minicli\Logging;
+
+enum LogLevel: string
+{
+    case INFO = 'INFO';
+    case WARNING = 'WARNING';
+    case ERROR = 'ERROR';
+    case DEBUG = 'DEBUG';
+}

--- a/src/Logging/LogType.php
+++ b/src/Logging/LogType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minicli\Logging;
+
+enum LogType: string
+{
+    case SINGLE = 'single';
+    case DAILY = 'daily';
+}

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -90,6 +90,10 @@ class Logger implements ServiceInterface
 
     private function writeLog(string $message): void
     {
+        if ( ! is_dir($this->logsPath)) {
+            mkdir($this->logsPath, 0775, true);
+        }
+
         $logFile = $this->getLogFilePath();
 
         if ( ! file_exists($logFile)) {

--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Minicli\Logging;
+
+use Minicli\App;
+use Minicli\ServiceInterface;
+
+class Logger implements ServiceInterface
+{
+    private const DEFAULT_TIMESTAMP_FORMAT = 'Y-m-d H:i:s';
+
+    private string $logsPath;
+
+    private LogType $logType;
+
+    private LogLevel $logLevel;
+
+    private string $timestampFormat;
+
+    public function load(App $app): void
+    {
+        $config = $app->config;
+
+        $this->logsPath = $app->logs_path;
+        $this->logType = LogType::from($config->logging['type'] ?? LogType::SINGLE->value);
+        $this->logLevel = LogLevel::from($config->logging['level'] ?? LogLevel::INFO->value);
+        $this->timestampFormat = $config->logging['timestamp_format'] ?? self::DEFAULT_TIMESTAMP_FORMAT;
+    }
+
+    /**
+     * @param string $message
+     * @param array<mixed> $context
+     * @param LogLevel|null $level
+     * @return void
+     */
+    public function log(string $message, array $context = [], LogLevel $level = null): void
+    {
+        $level ??= $this->logLevel;
+
+        $this->writeLog(sprintf(
+            "[%s] %s: %s%s\n",
+            date($this->timestampFormat),
+            $level->value,
+            $message,
+            [] === $context ? '' : ' - '.json_encode($context)
+        ));
+    }
+
+    /**
+     * @param string $message
+     * @param array<mixed> $context
+     * @return void
+     */
+    public function info(string $message, array $context = []): void
+    {
+        $this->log($message, $context, LogLevel::INFO);
+    }
+
+    /**
+     * @param string $message
+     * @param array<mixed> $context
+     * @return void
+     */
+    public function warning(string $message, array $context = []): void
+    {
+        $this->log($message, $context, LogLevel::WARNING);
+    }
+
+    /**
+     * @param string $message
+     * @param array<mixed> $context
+     * @return void
+     */
+    public function error(string $message, array $context = []): void
+    {
+        $this->log($message, $context, LogLevel::ERROR);
+    }
+
+    /**
+     * @param string $message
+     * @param array<mixed> $context
+     * @return void
+     */
+    public function debug(string $message, array $context = []): void
+    {
+        $this->log($message, $context, LogLevel::DEBUG);
+    }
+
+    private function writeLog(string $message): void
+    {
+        $logFile = $this->getLogFilePath();
+
+        if ( ! file_exists($logFile)) {
+            touch($logFile);
+        }
+
+        file_put_contents($logFile, $message, FILE_APPEND);
+    }
+
+    private function getLogFilePath(): string
+    {
+        return match ($this->logType) {
+            LogType::DAILY => sprintf("{$this->logsPath}/minicli-%s.log", date('Y-m-d')),
+            default => "{$this->logsPath}/minicli.log",
+        };
+    }
+}

--- a/tests/Assets/config/logging.php
+++ b/tests/Assets/config/logging.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Minicli\Logging\LogLevel;
+use Minicli\Logging\LogType;
+
+return [
+    /****************************************************************************
+     * Logging Configuration
+     * --------------------------------------------------------------------------
+     *
+     * This configuration defines the logging settings for your application.
+     *****************************************************************************/
+
+    'logging' => [
+        'type' => LogType::SINGLE->value,
+
+        'level' => LogLevel::INFO->value,
+
+        'timestamp_format' => 'Y-m-d H:i:s',
+    ],
+];

--- a/tests/Assets/logs/.gitignore
+++ b/tests/Assets/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Feature/Logging/LoggerTest.php
+++ b/tests/Feature/Logging/LoggerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+beforeEach(function (): void {
+    $this->app = getConfiguredApp();
+    $this->logPath = "{$this->app->logs_path}/minicli.log";
+});
+
+it('asserts App can log data', function (): void {
+    $this->app->logger->log('Testing minicli');
+
+    $log = file_get_contents($this->logPath);
+
+    expect($log)->toContain('INFO: Testing minicli');
+});
+
+it('asserts App can log data with INFO level', function (): void {
+    $this->app->logger->info('Testing minicli INFO logging');
+
+    $log = file_get_contents($this->logPath);
+
+    expect($log)->toContain('INFO: Testing minicli INFO logging');
+});
+
+it('asserts App can log data with WARNING level', function (): void {
+    $this->app->logger->warning('Testing minicli WARNING logging');
+
+    $log = file_get_contents($this->logPath);
+
+    expect($log)->toContain('WARNING: Testing minicli WARNING logging');
+});
+
+it('asserts App can log data with ERROR level', function (): void {
+    $this->app->logger->error('Testing minicli ERROR logging');
+
+    $log = file_get_contents($this->logPath);
+
+    expect($log)->toContain('ERROR: Testing minicli ERROR logging');
+});
+
+it('asserts App can log data with DEBUG level', function (): void {
+    $this->app->logger->debug('Testing minicli DEBUG logging');
+
+    $log = file_get_contents($this->logPath);
+
+    expect($log)->toContain('DEBUG: Testing minicli DEBUG logging');
+});
+
+it('asserts App can log data with context', function (): void {
+    $this->app->logger->log('Testing minicli context logging', ['context' => 'test']);
+
+    $log = file_get_contents($this->logPath);
+
+    expect($log)->toContain('INFO: Testing minicli context logging - {"context":"test"}');
+});


### PR DESCRIPTION
This PR adds a new built-in service for the Minicli called `Logger` that's a service to log messages to a file.

It provides two types of logging:

- **SINGLE:** Create a single file for all the logs
- **DAILY:** Create one log file per day

It also provides four levels of logs:

- **DEBUG**
- **INFO**
- **WARNING**
- **ERROR**