### PR TITLE
Fix BlueTheme FQCN Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ User-defined themes can also be created and defined in your project. In this cas
 
 ```php
 $app = new App([
-    'theme' => 'App\Theme\Blue'
+    'theme' => 'App\Theme\BlueTheme'
 ]);
 ```
 


### PR DESCRIPTION
While reading the docs, I just noticed that the class name of the custom blue theme is slightly wrong.