### PR TITLE
Pull Request: Add hasService and listServices Methods to App Class

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -62,14 +62,14 @@ class App
         $this->loadServices();
 
         $commandsPath = $this->config->app_path;
-        if ( ! is_array($commandsPath)) {
+        if (! is_array($commandsPath)) {
             $commandsPath = [$commandsPath];
         }
 
         $commandSources = [];
         foreach ($commandsPath as $path) {
             if (str_starts_with($path, '@')) {
-                $path = str_replace('@', $this->base_path.'/vendor/', $path).'/Command';
+                $path = str_replace('@', $this->base_path . '/vendor/', $path) . '/Command';
             }
             $commandSources[] = $path;
         }
@@ -81,7 +81,7 @@ class App
     {
         $root_app = dirname(__DIR__);
 
-        if ( ! is_file($root_app.'/vendor/autoload.php')) {
+        if (! is_file($root_app . '/vendor/autoload.php')) {
             $root_app = dirname(__DIR__, 4);
         }
 
@@ -120,12 +120,12 @@ class App
     public function addService(string $name, ServiceInterface|Closure $service): void
     {
         if ($service instanceof Closure) {
-            $this->container->bind($name, fn () => $service($this));
+            $this->container->bind($name, fn() => $service($this));
             return;
         }
 
         $service->load($this);
-        $this->container->bind($name, fn () => $service);
+        $this->container->bind($name, fn() => $service);
     }
 
     /**
@@ -155,7 +155,7 @@ class App
     public function setSignature(string $appSignature): void
     {
         $this->container->remove('appSignature');
-        $this->container->bind('appSignature', fn () => $appSignature);
+        $this->container->bind('appSignature', fn() => $appSignature);
     }
 
     public function setTheme(string $theme): void
@@ -226,7 +226,7 @@ class App
         try {
             $callable = $this->commandRegistry->getCallable((string) $input->command);
         } catch (Throwable $exception) {
-            if ( ! $this->config->debug) {
+            if (! $this->config->debug) {
                 $this->logger->error($exception->getMessage());
                 $this->error($exception->getMessage());
 
@@ -240,7 +240,7 @@ class App
             return true;
         }
 
-        if ( ! $this->config->debug) {
+        if (! $this->config->debug) {
             $this->error("The registered command is not a callable function.");
             return false;
         }
@@ -252,9 +252,9 @@ class App
     {
         $appRoot ??= $this->getAppRoot();
 
-        $this->container->bind('base_path', fn () => $appRoot);
-        $this->container->bind('config_path', fn () => "{$appRoot}/config");
-        $this->container->bind('logs_path', fn () => "{$appRoot}/logs");
+        $this->container->bind('base_path', fn() => $appRoot);
+        $this->container->bind('config_path', fn() => "{$appRoot}/config");
+        $this->container->bind('logs_path', fn() => "{$appRoot}/logs");
     }
 
     /**
@@ -266,7 +266,7 @@ class App
     protected function loadConfig(array $config, string $signature): void
     {
         $config = array_merge([
-            'app_path' => $this->base_path.'/Command',
+            'app_path' => $this->base_path . '/Command',
             'theme' => '',
             'debug' => true,
         ], $config);
@@ -297,5 +297,26 @@ class App
     protected function loadDefaultServices(): void
     {
         $this->addService('logger', new Logger());
+    }
+
+    /**
+     * List all registered services.
+     *
+     * @return array
+     */
+    public function listServices(): array
+    {
+        return $this->container->getBindings();
+    }
+
+    /**
+     * Check if a service is registered.
+     *
+     * @param string $serviceName
+     * @return bool
+     */
+    public function hasService(string $serviceName): bool
+    {
+        return $this->container->has($serviceName);
     }
 }

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -32,9 +32,7 @@ final class Container implements ArrayAccess
     /**
      * @return void
      */
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
     /**
      * @return static
@@ -137,13 +135,13 @@ final class Container implements ArrayAccess
             return $concrete($this);
         }
 
-        if ( ! class_exists($concrete)) {
+        if (! class_exists($concrete)) {
             throw new BindingResolutionException("Target class [{$concrete}] does not exist.", 0);
         }
 
         $reflector = new ReflectionClass($concrete);
 
-        if ( ! $reflector->isInstantiable()) {
+        if (! $reflector->isInstantiable()) {
             throw new BindingResolutionException("Target [{$concrete}] is not instantiable.");
         }
 
@@ -173,7 +171,7 @@ final class Container implements ArrayAccess
             // This is a much simpler version of what Laravel does
             $type = $dependency->getType(); // ReflectionType|null
 
-            if ( ! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
                 $declaringClass = null === $dependency->getDeclaringClass() ? '' : $dependency->getDeclaringClass()->getName();
                 throw new BindingResolutionException("Unresolvable dependency resolving [{$dependency}] in class {$declaringClass}");
             }
@@ -261,5 +259,13 @@ final class Container implements ArrayAccess
         return $this->contains(
             abstract: $id,
         );
+    }
+
+    /**
+     * @return array<string,array{concrete:Closure|string|null,shared:bool}>
+     */
+    public function getBindings(): array
+    {
+        return $this->bindings;
     }
 }

--- a/tests/Feature/AppTest.php
+++ b/tests/Feature/AppTest.php
@@ -10,7 +10,7 @@ use Minicli\Output\Adapter\DefaultPrinterAdapter;
 use Minicli\Exception\CommandNotFoundException;
 
 it('assert App is created')
-    ->expect(fn () => getBasicApp())
+    ->expect(fn() => getBasicApp())
     ->toBeInstanceOf(App::class);
 
 it('asserts App sets, gets and prints signature', function (): void {
@@ -28,25 +28,25 @@ it('asserts App reads configuration from config folder', function (): void {
     $app = getConfiguredApp();
 
     expect($app->getSignature())->toBe('Configured App')
-        ->and(realpath($app->config->app_path))->toBe(realpath(__DIR__.'/../Assets/Command'))
+        ->and(realpath($app->config->app_path))->toBe(realpath(__DIR__ . '/../Assets/Command'))
         ->and($app->config->theme)->toBe('unicorn')
         ->and($app->config->debug)->toBe(true);
 });
 
 it('asserts App has Config Service')
-    ->expect(fn () => getBasicApp()->config)
+    ->expect(fn() => getBasicApp()->config)
     ->toBeInstanceOf(Config::class);
 
 it('asserts App has CommandRegistry Service')
-    ->expect(fn () => getBasicApp()->commandRegistry)
+    ->expect(fn() => getBasicApp()->commandRegistry)
     ->toBeInstanceOf(CommandRegistry::class);
 
 it('asserts App has Printer Service')
-    ->expect(fn () => getBasicApp()->printer)
+    ->expect(fn() => getBasicApp()->printer)
     ->toBeInstanceOf(OutputHandler::class);
 
 it('asserts App returns null when a service is not found')
-    ->expect(fn () => getBasicApp()->inexistent_service)
+    ->expect(fn() => getBasicApp()->inexistent_service)
     ->toBeNull();
 
 it('asserts App parses command path with @vendor tag', function (): void {
@@ -64,14 +64,14 @@ it('asserts App parses command path with @vendor tag', function (): void {
 
 it('asserts App can handle a closure as a service', function (): void {
     $app = getBasicApp();
-    $app->addService('closure', fn () => 'closure');
+    $app->addService('closure', fn() => 'closure');
 
     expect($app->closure)->toBe('closure');
 });
 
 it('asserts Closure service gets passed the App instance', function (): void {
     $app = getBasicApp();
-    $app->addService('closure', fn ($app) => $app);
+    $app->addService('closure', fn($app) => $app);
 
     expect($app->closure)->toBe($app);
 });
@@ -164,3 +164,24 @@ it('asserts App shows error when required parameters are not provided', function
 
     $app->runCommand(['minicli', 'test', 'required']);
 })->expectOutputString("\n{$errorMissingParams}\n");
+
+
+it('asserts App can check if a service is registered', function (): void {
+    $app = getBasicApp();
+    $app->addService('test_service', fn() => 'test');
+
+    expect($app->hasService('test_service'))->toBeTrue();
+    expect($app->hasService('non_existent_service'))->toBeFalse();
+});
+
+it('asserts App can list all registered services', function (): void {
+    $app = getBasicApp();
+    $app->addService('service1', fn() => 'service1');
+    $app->addService('service2', fn() => 'service2');
+
+    $services = $app->listServices();
+
+    expect($services)->toBeArray();
+    expect(array_key_exists('service1', $services))->toBeTrue();
+    expect(array_key_exists('service2', $services))->toBeTrue();
+});


### PR DESCRIPTION

This pull request introduces two new methods, `hasService` and `listServices`, to the `App` class. These methods enhance the functionality of the `App` class by providing the ability to check if a service is registered and to list all registered services.

#### Changes
1. **New Methods in `App` Class:**
   - `hasService`: Checks if a service is registered in the container.
   - `listServices`: Lists all registered services in the container.

2. **Unit Tests:**
   - Added unit tests for `hasService` to verify it correctly identifies registered and non-registered services.
   - Added unit tests for `listServices` to verify it correctly lists all registered services.

#### Code Changes
```php
class App
{
    // Existing code...

    /**
     * List all registered services.
     *
     * @return array<string,array{concrete:Closure|string|null,shared:bool}>
     */
    public function listServices(): array
    {
        return $this->container->getBindings();
    }

    /**
     * Check if a service is registered.
     *
     * @param string $serviceName
     * @return bool
     */
    public function hasService(string $serviceName): bool
    {
        return $this->container->has($serviceName);
    }
}
```


This pull request aims to improve the service management capabilities of the `App` class by adding methods to check for and list registered services. Please review the changes and provide feedback. Thank you!