### PR TITLE
Fix implicitly nullable parameter declarations deprecated in PHP 8.4

### DIFF
--- a/src/Logging/Logger.php
+++ b/src/Logging/Logger.php
@@ -35,7 +35,7 @@ class Logger implements ServiceInterface
      * @param LogLevel|null $level
      * @return void
      */
-    public function log(string $message, array $context = [], LogLevel $level = null): void
+    public function log(string $message, array $context = [], ?LogLevel $level = null): void
     {
         $level ??= $this->logLevel;
 

--- a/src/Output/Helper/TableHelper.php
+++ b/src/Output/Helper/TableHelper.php
@@ -103,7 +103,7 @@ class TableHelper
      * @param OutputFilterInterface|null $filter In case no filter is provided, a SimpleOutputFilter is used by default.
      * @return string
      */
-    public function getFormattedTable(OutputFilterInterface $filter = null): string
+    public function getFormattedTable(?OutputFilterInterface $filter = null): string
     {
         $filter = $filter ?? new SimpleOutputFilter();
 


### PR DESCRIPTION
This is the fix for this issue: https://github.com/minicli/minicli/issues/112

At the moment, I've found issues with two classes only:

- src/Logging/Logger.php
- src/Output/Helper/TableHelper.php

There is probably some other reference that I haven't used yet.